### PR TITLE
feat: Go daemon session layer + PTY management

### DIFF
--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -1,0 +1,142 @@
+// Package config provides configuration loading for the zplex daemon.
+// It reads from TOML files, environment variables, and CLI flags with
+// a well-defined priority: defaults < config file < env vars < CLI flags.
+package config
+
+import (
+	"errors"
+	"flag"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Default values for daemon configuration.
+const (
+	DefaultPort       = 17732
+	DefaultShell      = "powershell"
+	DefaultBufferSize = 102400
+)
+
+// Config holds the runtime configuration for the zplex daemon.
+type Config struct {
+	Port         int
+	DefaultShell string
+	BufferSize   int
+}
+
+// fileConfig mirrors the TOML file structure with a [daemon] section.
+type fileConfig struct {
+	Daemon daemonConfig `toml:"daemon"`
+}
+
+// daemonConfig maps the fields inside the [daemon] TOML section.
+type daemonConfig struct {
+	Port         int    `toml:"port"`
+	DefaultShell string `toml:"default_shell"`
+	BufferSize   int    `toml:"buffer_size"`
+}
+
+// Load builds a Config by layering sources in priority order:
+// hardcoded defaults < ~/.zplex/config.toml < environment variables < CLI flags.
+func Load() (*Config, error) {
+	slog.Info("config.Load: starting configuration load")
+
+	// Layer 0: hardcoded defaults.
+	cfg := &Config{
+		Port:         DefaultPort,
+		DefaultShell: DefaultShell,
+		BufferSize:   DefaultBufferSize,
+	}
+
+	// Layer 1: TOML config file.
+	if err := applyFileConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	// Layer 2: environment variables.
+	applyEnvConfig(cfg)
+
+	// Layer 3: CLI flags (highest priority).
+	applyCLIFlags(cfg)
+
+	slog.Info("config.Load: configuration loaded",
+		slog.Int("port", cfg.Port),
+		slog.String("default_shell", cfg.DefaultShell),
+		slog.Int("buffer_size", cfg.BufferSize),
+	)
+	return cfg, nil
+}
+
+// applyFileConfig reads ~/.zplex/config.toml and applies any values found.
+// If the file does not exist, it silently returns without error.
+func applyFileConfig(cfg *Config) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		slog.Warn("config: unable to determine home directory, skipping config file",
+			slog.String("error", err.Error()),
+		)
+		return nil
+	}
+
+	path := filepath.Join(home, ".zplex", "config.toml")
+
+	var fc fileConfig
+	_, err = toml.DecodeFile(path, &fc)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// No config file — use defaults without logging an error.
+			return nil
+		}
+		return err
+	}
+
+	slog.Info("config: loaded config file", slog.String("path", path))
+
+	if fc.Daemon.Port != 0 {
+		cfg.Port = fc.Daemon.Port
+	}
+	if fc.Daemon.DefaultShell != "" {
+		cfg.DefaultShell = fc.Daemon.DefaultShell
+	}
+	if fc.Daemon.BufferSize != 0 {
+		cfg.BufferSize = fc.Daemon.BufferSize
+	}
+
+	return nil
+}
+
+// applyEnvConfig overrides config values with ZPLEX_PORT and ZPLEX_SHELL
+// environment variables when they are set.
+func applyEnvConfig(cfg *Config) {
+	if portStr := os.Getenv("ZPLEX_PORT"); portStr != "" {
+		port, err := strconv.Atoi(portStr)
+		if err != nil {
+			slog.Warn("config: invalid ZPLEX_PORT value, ignoring",
+				slog.String("value", portStr),
+				slog.String("error", err.Error()),
+			)
+		} else {
+			cfg.Port = port
+		}
+	}
+
+	if shell := os.Getenv("ZPLEX_SHELL"); shell != "" {
+		cfg.DefaultShell = shell
+	}
+}
+
+// applyCLIFlags parses --port and --shell flags from the command line.
+// CLI flags take highest priority and override all other sources.
+func applyCLIFlags(cfg *Config) {
+	port := flag.Int("port", cfg.Port, "daemon listen port")
+	shell := flag.String("shell", cfg.DefaultShell, "default shell for new sessions")
+
+	flag.Parse()
+
+	cfg.Port = *port
+	cfg.DefaultShell = *shell
+}

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -2,4 +2,14 @@ module github.com/zac15987/zplex/daemon
 
 go 1.26
 
-require github.com/BurntSushi/toml v1.5.0
+require (
+	github.com/BurntSushi/toml v1.5.0
+	github.com/aymanbagabas/go-pty v0.2.2
+)
+
+require (
+	github.com/creack/pty v1.1.21 // indirect
+	github.com/u-root/u-root v0.11.0 // indirect
+	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/sys v0.16.0 // indirect
+)

--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -1,0 +1,5 @@
+module github.com/zac15987/zplex/daemon
+
+go 1.26
+
+require github.com/BurntSushi/toml v1.5.0

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,0 +1,2 @@
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -1,2 +1,16 @@
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/aymanbagabas/go-pty v0.2.2 h1:YZREB4eSj+1xdbbItIokX0ekjjeifgJOA+ZvxU4/WM8=
+github.com/aymanbagabas/go-pty v0.2.2/go.mod h1:gfvlwH+0U66BCwxJREjJaAOEs9H1OFf3YFjI9WSiZ04=
+github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
+github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/u-root/gobusybox/src v0.0.0-20221229083637-46b2883a7f90 h1:zTk5683I9K62wtZ6eUa6vu6IWwVHXPnoKK5n2unAwv0=
+github.com/u-root/gobusybox/src v0.0.0-20221229083637-46b2883a7f90/go.mod h1:lYt+LVfZBBwDZ3+PHk4k/c/TnKOkjJXiJO73E32Mmpc=
+github.com/u-root/u-root v0.11.0 h1:6gCZLOeRyevw7gbTwMj3fKxnr9+yHFlgF3N7udUVNO8=
+github.com/u-root/u-root v0.11.0/go.mod h1:DBkDtiZyONk9hzVEdB/PWI9B4TxDkElWlVTHseglrZY=
+golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
+golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/zac15987/zplex/daemon/config"
+	"github.com/zac15987/zplex/daemon/session"
+)
+
+func main() {
+	// Load config (calls flag.Parse() internally).
+	cfg, err := config.Load()
+	if err != nil {
+		slog.Error("failed to load config", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+
+	// Create SessionManager with config-driven defaults.
+	mgr := session.NewSessionManager(cfg.DefaultShell, cfg.BufferSize)
+
+	slog.Info("zplex daemon started",
+		slog.Int("port", cfg.Port),
+		slog.String("shell", cfg.DefaultShell),
+		slog.Int("buffer_size", cfg.BufferSize),
+	)
+
+	// Block until SIGINT or SIGTERM. On Windows SIGTERM is not delivered by
+	// the OS, but os.Interrupt covers Ctrl+C. We include syscall.SIGTERM
+	// for Unix compatibility.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	sig := <-sigCh
+	slog.Info("received shutdown signal", slog.String("signal", sig.String()))
+
+	// Graceful shutdown — close every PTY session.
+	mgr.Shutdown()
+	slog.Info("zplex daemon stopped")
+}

--- a/daemon/session/manager.go
+++ b/daemon/session/manager.go
@@ -1,0 +1,153 @@
+package session
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// ErrSessionNotFound is returned when a requested session ID does not exist.
+var ErrSessionNotFound = errors.New("session not found")
+
+// SessionManager owns all active sessions and provides CRUD operations.
+// It is safe for concurrent use.
+type SessionManager struct {
+	mu         sync.RWMutex
+	sessions   map[string]*Session
+	shell      string // default shell from config
+	bufferSize int    // ring buffer capacity from config
+}
+
+// NewSessionManager creates a SessionManager configured with the given
+// default shell and per-session ring buffer size.
+func NewSessionManager(defaultShell string, bufferSize int) *SessionManager {
+	slog.Info("manager: initialized",
+		slog.String("shell", defaultShell),
+		slog.Int("buffer_size", bufferSize),
+	)
+	return &SessionManager{
+		sessions:   make(map[string]*Session),
+		shell:      defaultShell,
+		bufferSize: bufferSize,
+	}
+}
+
+// Create spawns a new PTY-backed session with the given title and adds it
+// to the manager's session map. The session ID is generated randomly.
+func (m *SessionManager) Create(title string) (*Session, error) {
+	slog.Info("manager.Create: creating session", slog.String("title", title))
+
+	id := "s-" + generateID()
+
+	sess, err := NewSession(id, title, m.shell, m.bufferSize)
+	if err != nil {
+		slog.Error("manager.Create: failed to create session",
+			slog.String("title", title),
+			slog.String("error", err.Error()),
+		)
+		return nil, err
+	}
+
+	m.mu.Lock()
+	m.sessions[id] = sess
+	m.mu.Unlock()
+
+	slog.Info("manager.Create: session created", slog.String("session_id", id))
+	return sess, nil
+}
+
+// Get returns the session with the given ID. If no session exists for that ID,
+// it returns ErrSessionNotFound.
+func (m *SessionManager) Get(id string) (*Session, error) {
+	slog.Info("manager.Get: looking up session", slog.String("session_id", id))
+
+	m.mu.RLock()
+	sess, ok := m.sessions[id]
+	m.mu.RUnlock()
+
+	if !ok {
+		slog.Warn("manager.Get: session not found", slog.String("session_id", id))
+		return nil, fmt.Errorf("%w: %s", ErrSessionNotFound, id)
+	}
+	return sess, nil
+}
+
+// List returns a snapshot of metadata for every session the manager owns.
+func (m *SessionManager) List() []SessionInfo {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	slog.Info("manager.List: listing sessions", slog.Int("count", len(m.sessions)))
+
+	infos := make([]SessionInfo, 0, len(m.sessions))
+	for _, sess := range m.sessions {
+		infos = append(infos, sess.Info())
+	}
+	return infos
+}
+
+// Kill removes a session from the manager and closes it. If the session ID
+// does not exist, it returns ErrSessionNotFound.
+func (m *SessionManager) Kill(id string) error {
+	slog.Info("manager.Kill: killing session", slog.String("session_id", id))
+
+	m.mu.Lock()
+	sess, ok := m.sessions[id]
+	if !ok {
+		m.mu.Unlock()
+		slog.Warn("manager.Kill: session not found", slog.String("session_id", id))
+		return fmt.Errorf("%w: %s", ErrSessionNotFound, id)
+	}
+	delete(m.sessions, id)
+	m.mu.Unlock()
+
+	if err := sess.Close(); err != nil {
+		slog.Warn("manager.Kill: error closing session",
+			slog.String("session_id", id),
+			slog.String("error", err.Error()),
+		)
+		return err
+	}
+
+	slog.Info("manager.Kill: session killed", slog.String("session_id", id))
+	return nil
+}
+
+// Shutdown closes every session the manager owns and clears the session map.
+// This is intended for graceful daemon shutdown.
+func (m *SessionManager) Shutdown() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	slog.Info("manager.Shutdown: shutting down all sessions", slog.Int("count", len(m.sessions)))
+
+	for id, sess := range m.sessions {
+		if err := sess.Close(); err != nil {
+			slog.Warn("manager.Shutdown: error closing session",
+				slog.String("session_id", id),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+
+	// Clear the map so the manager holds no stale references.
+	m.sessions = make(map[string]*Session)
+
+	slog.Info("manager.Shutdown: all sessions closed")
+}
+
+// generateID produces a 16-character hex string from 8 random bytes.
+// In the extremely unlikely event that crypto/rand fails, it falls back
+// to a nanosecond timestamp.
+func generateID() string {
+	b := make([]byte, 8)
+	_, err := rand.Read(b)
+	if err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b)
+}

--- a/daemon/session/manager_test.go
+++ b/daemon/session/manager_test.go
@@ -173,17 +173,48 @@ func TestSessionInfo(t *testing.T) {
 // Session auto-detect exit — verify Done() channel and status change.
 // ---------------------------------------------------------------------------
 
+func TestSession_NaturalExit(t *testing.T) {
+	// Test that when the shell exits naturally (via "exit" command),
+	// the session detects it: Status becomes "exited" and Done() closes.
+	sess, err := NewSession("test-natural-exit", "natural exit test", "powershell", 102400)
+	if err != nil {
+		t.Fatalf("NewSession failed: %v", err)
+	}
+
+	// Verify session starts in running state.
+	info := sess.Info()
+	if info.Status != "running" {
+		t.Fatalf("expected initial status %q, got %q", "running", info.Status)
+	}
+
+	// Tell the shell to exit naturally.
+	_, err = sess.Write([]byte("exit\r\n"))
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	// Wait for the session to detect exit (with timeout).
+	select {
+	case <-sess.Done():
+		// Good — the session detected the natural exit.
+	case <-time.After(10 * time.Second):
+		sess.Close()
+		t.Fatal("timed out waiting for session to detect natural exit")
+	}
+
+	// Status should now be "exited" with exit code 0.
+	info = sess.Info()
+	if info.Status != "exited" {
+		t.Errorf("expected status %q, got %q", "exited", info.Status)
+	}
+	if info.ExitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", info.ExitCode)
+	}
+}
+
 func TestSession_CloseSignalsDone(t *testing.T) {
 	// Test that Close() terminates the subprocess, closes the Done
 	// channel, and transitions Status to "exited".
-	//
-	// NOTE: On Windows ConPTY, pty.Read() does not return EOF when the
-	// child process exits naturally — it blocks indefinitely. This means
-	// the readLoop never reaches cmd.Wait() for a naturally exiting
-	// process. Auto-detect of natural exit requires a design change in
-	// readLoop (e.g. calling cmd.Wait in a separate goroutine). For now
-	// we test the Close()-driven exit path, which is the primary
-	// mechanism used by Kill() and Shutdown().
 	sess, err := NewSession("test-close-done", "close done test", "cmd.exe", 102400)
 	if err != nil {
 		t.Fatalf("NewSession failed: %v", err)

--- a/daemon/session/manager_test.go
+++ b/daemon/session/manager_test.go
@@ -1,0 +1,350 @@
+package session
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Ring buffer tests — verify the unexported ringBuffer directly.
+// ---------------------------------------------------------------------------
+
+func TestRingBuffer_Empty(t *testing.T) {
+	rb := newRingBuffer(100)
+	got := rb.ReadAll()
+	if len(got) != 0 {
+		t.Errorf("expected empty buffer, got %d bytes", len(got))
+	}
+}
+
+func TestRingBuffer_BasicWriteRead(t *testing.T) {
+	rb := newRingBuffer(100)
+	rb.Write([]byte("hello"))
+	got := rb.ReadAll()
+	if string(got) != "hello" {
+		t.Errorf("expected %q, got %q", "hello", string(got))
+	}
+}
+
+func TestRingBuffer_MultipleWrites(t *testing.T) {
+	rb := newRingBuffer(100)
+	rb.Write([]byte("hello "))
+	rb.Write([]byte("world"))
+	got := rb.ReadAll()
+	if string(got) != "hello world" {
+		t.Errorf("expected %q, got %q", "hello world", string(got))
+	}
+}
+
+func TestRingBuffer_ExactCapacity(t *testing.T) {
+	rb := newRingBuffer(5)
+	rb.Write([]byte("abcde"))
+	got := rb.ReadAll()
+	if string(got) != "abcde" {
+		t.Errorf("expected %q, got %q", "abcde", string(got))
+	}
+}
+
+func TestRingBuffer_Overflow(t *testing.T) {
+	rb := newRingBuffer(10)
+	// Write 15 bytes — only last 10 should be retained.
+	rb.Write([]byte("abcdefghijklmno"))
+	got := rb.ReadAll()
+	if string(got) != "fghijklmno" {
+		t.Errorf("expected %q, got %q", "fghijklmno", string(got))
+	}
+}
+
+func TestRingBuffer_WrapAround(t *testing.T) {
+	rb := newRingBuffer(10)
+	rb.Write([]byte("12345678")) // 8 bytes, w=8, full=false
+	rb.Write([]byte("abcd"))     // 4 bytes, wraps around
+	// After wrap: buf=[c,d,3,4,5,6,7,8,a,b], w=2, full=true
+	// ReadAll: buf[2:] + buf[:2] = "345678ab" + "cd" = "345678abcd"
+	got := rb.ReadAll()
+	if string(got) != "345678abcd" {
+		t.Errorf("expected %q, got %q", "345678abcd", string(got))
+	}
+}
+
+func TestRingBuffer_ZeroCapacityClamped(t *testing.T) {
+	// Zero capacity should be clamped to 1, not panic.
+	rb := newRingBuffer(0)
+	rb.Write([]byte("abc"))
+	got := rb.ReadAll()
+	// Only the last byte fits in a 1-byte buffer.
+	if string(got) != "c" {
+		t.Errorf("expected %q, got %q", "c", string(got))
+	}
+}
+
+func TestRingBuffer_WriteReturnsFullLength(t *testing.T) {
+	rb := newRingBuffer(5)
+	n, err := rb.Write([]byte("long data exceeding buffer"))
+	if err != nil {
+		t.Fatalf("Write returned unexpected error: %v", err)
+	}
+	if n != len("long data exceeding buffer") {
+		t.Errorf("expected Write to return %d, got %d", len("long data exceeding buffer"), n)
+	}
+}
+
+func TestRingBuffer_EmptyWrite(t *testing.T) {
+	rb := newRingBuffer(10)
+	n, err := rb.Write([]byte{})
+	if err != nil {
+		t.Fatalf("empty Write returned unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("expected 0 from empty Write, got %d", n)
+	}
+	got := rb.ReadAll()
+	if len(got) != 0 {
+		t.Errorf("expected empty buffer after empty write, got %d bytes", len(got))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session tests — spawn real PTY processes.
+// ---------------------------------------------------------------------------
+
+func TestSessionCreate_PTYIO(t *testing.T) {
+	sess, err := NewSession("test-io", "test IO session", "powershell", 102400)
+	if err != nil {
+		t.Fatalf("NewSession failed: %v", err)
+	}
+	defer sess.Close()
+
+	if sess.Status != "running" {
+		t.Errorf("expected status %q, got %q", "running", sess.Status)
+	}
+	if sess.PID <= 0 {
+		t.Errorf("expected positive PID, got %d", sess.PID)
+	}
+
+	// Write a command that produces recognizable output.
+	_, err = sess.Write([]byte("echo hello-zplex\r\n"))
+	if err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	// Give the shell time to process the command and produce output.
+	time.Sleep(2 * time.Second)
+
+	// The ring buffer should have captured some output.
+	data := sess.BufferData()
+	if len(data) == 0 {
+		t.Error("expected ring buffer to contain data after command, got empty")
+	}
+
+	// The output should contain our echo string.
+	if !strings.Contains(string(data), "hello-zplex") {
+		t.Errorf("expected buffer to contain %q, got %q", "hello-zplex", string(data))
+	}
+}
+
+func TestSessionInfo(t *testing.T) {
+	sess, err := NewSession("test-info", "info test", "powershell", 102400)
+	if err != nil {
+		t.Fatalf("NewSession failed: %v", err)
+	}
+	defer sess.Close()
+
+	info := sess.Info()
+	if info.ID != "test-info" {
+		t.Errorf("expected ID %q, got %q", "test-info", info.ID)
+	}
+	if info.Title != "info test" {
+		t.Errorf("expected Title %q, got %q", "info test", info.Title)
+	}
+	if info.Status != "running" {
+		t.Errorf("expected Status %q, got %q", "running", info.Status)
+	}
+	if info.PID <= 0 {
+		t.Errorf("expected positive PID, got %d", info.PID)
+	}
+	if info.CreatedAt.IsZero() {
+		t.Error("expected non-zero CreatedAt")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session auto-detect exit — verify Done() channel and status change.
+// ---------------------------------------------------------------------------
+
+func TestSession_CloseSignalsDone(t *testing.T) {
+	// Test that Close() terminates the subprocess, closes the Done
+	// channel, and transitions Status to "exited".
+	//
+	// NOTE: On Windows ConPTY, pty.Read() does not return EOF when the
+	// child process exits naturally — it blocks indefinitely. This means
+	// the readLoop never reaches cmd.Wait() for a naturally exiting
+	// process. Auto-detect of natural exit requires a design change in
+	// readLoop (e.g. calling cmd.Wait in a separate goroutine). For now
+	// we test the Close()-driven exit path, which is the primary
+	// mechanism used by Kill() and Shutdown().
+	sess, err := NewSession("test-close-done", "close done test", "cmd.exe", 102400)
+	if err != nil {
+		t.Fatalf("NewSession failed: %v", err)
+	}
+
+	// Verify session starts in running state.
+	info := sess.Info()
+	if info.Status != "running" {
+		t.Fatalf("expected initial status %q, got %q", "running", info.Status)
+	}
+
+	// Close the session — this kills the process and closes the PTY.
+	err = sess.Close()
+	if err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	// Done channel should be closed after Close returns.
+	select {
+	case <-sess.Done():
+		// Good — the channel is closed.
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for Done channel after Close")
+	}
+
+	// Status should now be "exited".
+	info = sess.Info()
+	if info.Status != "exited" {
+		t.Errorf("expected status %q after Close, got %q", "exited", info.Status)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Manager CRUD tests — exercise the SessionManager's full lifecycle.
+// ---------------------------------------------------------------------------
+
+func TestManager_CRUD(t *testing.T) {
+	mgr := NewSessionManager("powershell", 102400)
+	defer mgr.Shutdown()
+
+	// Create
+	sess, err := mgr.Create("crud test")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if sess.ID == "" {
+		t.Error("session ID should not be empty")
+	}
+	if sess.Status != "running" {
+		t.Errorf("expected status %q, got %q", "running", sess.Status)
+	}
+
+	// Get — existing session
+	got, err := mgr.Get(sess.ID)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got.ID != sess.ID {
+		t.Errorf("Get returned wrong session: %q != %q", got.ID, sess.ID)
+	}
+
+	// Get — nonexistent session
+	_, err = mgr.Get("nonexistent-id")
+	if err == nil {
+		t.Error("Get should return an error for a nonexistent session ID")
+	}
+
+	// List — should contain exactly one session
+	infos := mgr.List()
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 session in list, got %d", len(infos))
+	}
+	if infos[0].ID != sess.ID {
+		t.Errorf("listed session ID %q does not match created ID %q", infos[0].ID, sess.ID)
+	}
+
+	// Kill
+	id := sess.ID
+	err = mgr.Kill(id)
+	if err != nil {
+		t.Fatalf("Kill failed: %v", err)
+	}
+
+	// Get after Kill — should fail
+	_, err = mgr.Get(id)
+	if err == nil {
+		t.Error("Get should fail after session is killed")
+	}
+
+	// List after Kill — should be empty
+	infos = mgr.List()
+	if len(infos) != 0 {
+		t.Errorf("expected 0 sessions after kill, got %d", len(infos))
+	}
+
+	// Kill nonexistent — should return error
+	err = mgr.Kill("nonexistent-id")
+	if err == nil {
+		t.Error("Kill should return an error for a nonexistent session ID")
+	}
+}
+
+func TestManager_MultipleSessions(t *testing.T) {
+	mgr := NewSessionManager("powershell", 102400)
+	defer mgr.Shutdown()
+
+	// Create multiple sessions.
+	s1, err := mgr.Create("session one")
+	if err != nil {
+		t.Fatalf("Create session one failed: %v", err)
+	}
+	s2, err := mgr.Create("session two")
+	if err != nil {
+		t.Fatalf("Create session two failed: %v", err)
+	}
+
+	if s1.ID == s2.ID {
+		t.Errorf("two sessions should have distinct IDs, both got %q", s1.ID)
+	}
+
+	infos := mgr.List()
+	if len(infos) != 2 {
+		t.Fatalf("expected 2 sessions, got %d", len(infos))
+	}
+
+	// Kill one, verify the other remains.
+	err = mgr.Kill(s1.ID)
+	if err != nil {
+		t.Fatalf("Kill session one failed: %v", err)
+	}
+
+	infos = mgr.List()
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 session after killing one, got %d", len(infos))
+	}
+	if infos[0].ID != s2.ID {
+		t.Errorf("remaining session should be %q, got %q", s2.ID, infos[0].ID)
+	}
+}
+
+func TestManager_Shutdown(t *testing.T) {
+	mgr := NewSessionManager("powershell", 102400)
+
+	_, err := mgr.Create("shutdown test 1")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	_, err = mgr.Create("shutdown test 2")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	infos := mgr.List()
+	if len(infos) != 2 {
+		t.Fatalf("expected 2 sessions before shutdown, got %d", len(infos))
+	}
+
+	mgr.Shutdown()
+
+	infos = mgr.List()
+	if len(infos) != 0 {
+		t.Errorf("expected 0 sessions after shutdown, got %d", len(infos))
+	}
+}

--- a/daemon/session/session.go
+++ b/daemon/session/session.go
@@ -33,11 +33,12 @@ type Session struct {
 	PID       int
 	ExitCode  int
 
-	pty     pty.Pty     // PTY handle (ConPTY on Windows, /dev/ptmx on Unix)
-	cmd     *pty.Cmd    // the running subprocess
-	ringBuf *ringBuffer // circular buffer for replay
-	mu      sync.Mutex  // protects Status, ExitCode, ringBuf writes
-	done    chan struct{}
+	pty      pty.Pty     // PTY handle (ConPTY on Windows, /dev/ptmx on Unix)
+	cmd      *pty.Cmd    // the running subprocess
+	ringBuf  *ringBuffer // circular buffer for replay
+	mu       sync.Mutex  // protects Status, ExitCode, ringBuf writes
+	done     chan struct{}
+	closePTY sync.Once // ensures PTY is closed exactly once
 }
 
 // readBufSize is the size of the temporary buffer used when reading PTY output
@@ -100,7 +101,39 @@ func NewSession(id, title, shell string, bufferSize int) (*Session, error) {
 
 // readLoop continuously reads PTY output, writes it into the ring buffer,
 // and waits for the subprocess to exit.
+//
+// On Windows ConPTY, pty.Read() does not return EOF when the child process
+// exits — it blocks indefinitely. To handle this, we run cmd.Wait() in a
+// separate goroutine. When the process exits, that goroutine closes the PTY,
+// which unblocks the Read call with an error so the loop can terminate.
 func (s *Session) readLoop() {
+	// waitDone is closed once cmd.Wait() completes and the exit code is captured.
+	waitDone := make(chan struct{})
+	go func() {
+		defer close(waitDone)
+		waitErr := s.cmd.Wait()
+		exitCode := 0
+		if s.cmd.ProcessState != nil {
+			exitCode = s.cmd.ProcessState.ExitCode()
+		} else if waitErr != nil {
+			exitCode = -1
+		}
+
+		s.mu.Lock()
+		s.Status = "exited"
+		s.ExitCode = exitCode
+		s.mu.Unlock()
+
+		slog.Info("session.readLoop: process exited",
+			slog.String("session_id", s.ID),
+			slog.Int("exit_code", exitCode),
+		)
+
+		// Close the PTY to unblock any pending Read call.
+		// Uses sync.Once so it's safe if Close() also triggers this.
+		s.closePTY.Do(func() { s.pty.Close() })
+	}()
+
 	buf := make([]byte, readBufSize)
 	for {
 		n, err := s.pty.Read(buf)
@@ -110,9 +143,8 @@ func (s *Session) readLoop() {
 			s.mu.Unlock()
 		}
 		if err != nil {
-			// EOF or read error — process has likely exited.
 			if err != io.EOF {
-				slog.Warn("session.readLoop: PTY read error",
+				slog.Debug("session.readLoop: PTY read ended",
 					slog.String("session_id", s.ID),
 					slog.String("error", err.Error()),
 				)
@@ -121,26 +153,13 @@ func (s *Session) readLoop() {
 		}
 	}
 
-	// Wait for the subprocess to finish and capture the exit code.
-	waitErr := s.cmd.Wait()
-	exitCode := 0
-	if s.cmd.ProcessState != nil {
-		exitCode = s.cmd.ProcessState.ExitCode()
-	} else if waitErr != nil {
-		// If ProcessState is nil but Wait returned an error, mark as -1.
-		exitCode = -1
-	}
-
-	s.mu.Lock()
-	s.Status = "exited"
-	s.ExitCode = exitCode
-	s.mu.Unlock()
+	// Wait for the cmd.Wait goroutine to finish capturing exit state.
+	<-waitDone
 
 	close(s.done)
 
-	slog.Info("session.readLoop: session exited",
+	slog.Info("session.readLoop: session fully stopped",
 		slog.String("session_id", s.ID),
-		slog.Int("exit_code", exitCode),
 	)
 }
 
@@ -174,13 +193,15 @@ func (s *Session) Close() error {
 		}
 	}
 
-	err := s.pty.Close()
+	// Close the PTY. The readLoop's Wait goroutine may have already closed
+	// it after the process exited naturally; sync.Once ensures no double close.
+	s.closePTY.Do(func() { s.pty.Close() })
 
 	// Wait for the readLoop goroutine to finish.
 	<-s.done
 
 	slog.Info("session.Close: session closed", slog.String("session_id", s.ID))
-	return err
+	return nil
 }
 
 // Done returns a channel that is closed when the session's subprocess exits.

--- a/daemon/session/session.go
+++ b/daemon/session/session.go
@@ -1,0 +1,299 @@
+// Package session manages PTY-backed terminal sessions for the zplex daemon.
+// Each session owns a pseudo-terminal, a subprocess, and a ring buffer that
+// stores recent output for reconnect replay.
+package session
+
+import (
+	"io"
+	"log/slog"
+	"sync"
+	"time"
+
+	pty "github.com/aymanbagabas/go-pty"
+)
+
+// SessionInfo is a JSON-serializable snapshot of session metadata.
+type SessionInfo struct {
+	ID        string    `json:"id"`
+	Title     string    `json:"title"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	PID       int       `json:"pid"`
+	ExitCode  int       `json:"exit_code"`
+}
+
+// Session represents a single PTY-backed terminal session.
+// It owns a pseudo-terminal, a running command, and a ring buffer that
+// accumulates recent output for reconnect replay.
+type Session struct {
+	ID        string
+	Title     string
+	Status    string // "running" or "exited"
+	CreatedAt time.Time
+	PID       int
+	ExitCode  int
+
+	pty     pty.Pty     // PTY handle (ConPTY on Windows, /dev/ptmx on Unix)
+	cmd     *pty.Cmd    // the running subprocess
+	ringBuf *ringBuffer // circular buffer for replay
+	mu      sync.Mutex  // protects Status, ExitCode, ringBuf writes
+	done    chan struct{}
+}
+
+// readBufSize is the size of the temporary buffer used when reading PTY output
+// in the background goroutine.
+const readBufSize = 8192
+
+// NewSession spawns a new PTY-backed shell session.
+// The caller provides a unique id, a human-readable title, the shell executable
+// to run, and the ring-buffer capacity in bytes.
+func NewSession(id, title, shell string, bufferSize int) (*Session, error) {
+	slog.Info("session.NewSession: creating session",
+		slog.String("session_id", id),
+		slog.String("title", title),
+		slog.String("shell", shell),
+		slog.Int("buffer_size", bufferSize),
+	)
+
+	ptmx, err := pty.New()
+	if err != nil {
+		slog.Error("session.NewSession: failed to create PTY",
+			slog.String("session_id", id),
+			slog.String("error", err.Error()),
+		)
+		return nil, err
+	}
+
+	cmd := ptmx.Command(shell)
+	if err := cmd.Start(); err != nil {
+		slog.Error("session.NewSession: failed to start command",
+			slog.String("session_id", id),
+			slog.String("shell", shell),
+			slog.String("error", err.Error()),
+		)
+		ptmx.Close()
+		return nil, err
+	}
+
+	pid := cmd.Process.Pid
+
+	s := &Session{
+		ID:        id,
+		Title:     title,
+		Status:    "running",
+		CreatedAt: time.Now(),
+		PID:       pid,
+		pty:       ptmx,
+		cmd:       cmd,
+		ringBuf:   newRingBuffer(bufferSize),
+		done:      make(chan struct{}),
+	}
+
+	go s.readLoop()
+
+	slog.Info("session.NewSession: session created",
+		slog.String("session_id", id),
+		slog.Int("pid", pid),
+	)
+	return s, nil
+}
+
+// readLoop continuously reads PTY output, writes it into the ring buffer,
+// and waits for the subprocess to exit.
+func (s *Session) readLoop() {
+	buf := make([]byte, readBufSize)
+	for {
+		n, err := s.pty.Read(buf)
+		if n > 0 {
+			s.mu.Lock()
+			s.ringBuf.Write(buf[:n])
+			s.mu.Unlock()
+		}
+		if err != nil {
+			// EOF or read error — process has likely exited.
+			if err != io.EOF {
+				slog.Warn("session.readLoop: PTY read error",
+					slog.String("session_id", s.ID),
+					slog.String("error", err.Error()),
+				)
+			}
+			break
+		}
+	}
+
+	// Wait for the subprocess to finish and capture the exit code.
+	waitErr := s.cmd.Wait()
+	exitCode := 0
+	if s.cmd.ProcessState != nil {
+		exitCode = s.cmd.ProcessState.ExitCode()
+	} else if waitErr != nil {
+		// If ProcessState is nil but Wait returned an error, mark as -1.
+		exitCode = -1
+	}
+
+	s.mu.Lock()
+	s.Status = "exited"
+	s.ExitCode = exitCode
+	s.mu.Unlock()
+
+	close(s.done)
+
+	slog.Info("session.readLoop: session exited",
+		slog.String("session_id", s.ID),
+		slog.Int("exit_code", exitCode),
+	)
+}
+
+// Read reads PTY output directly. This is the primary interface for
+// WebSocket consumers that forward live output to the frontend.
+// The ring buffer is populated separately by the background goroutine.
+func (s *Session) Read(p []byte) (int, error) {
+	return s.pty.Read(p)
+}
+
+// Write sends data to the PTY's stdin, which is forwarded to the subprocess.
+func (s *Session) Write(p []byte) (int, error) {
+	return s.pty.Write(p)
+}
+
+// Close kills the subprocess (if still running), closes the PTY, and waits
+// for the background read goroutine to finish.
+func (s *Session) Close() error {
+	slog.Info("session.Close: closing session", slog.String("session_id", s.ID))
+
+	s.mu.Lock()
+	isRunning := s.Status == "running"
+	s.mu.Unlock()
+
+	if isRunning {
+		if err := s.cmd.Process.Kill(); err != nil {
+			slog.Warn("session.Close: failed to kill process",
+				slog.String("session_id", s.ID),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+
+	err := s.pty.Close()
+
+	// Wait for the readLoop goroutine to finish.
+	<-s.done
+
+	slog.Info("session.Close: session closed", slog.String("session_id", s.ID))
+	return err
+}
+
+// Done returns a channel that is closed when the session's subprocess exits.
+// External code can select on this to react to session termination.
+func (s *Session) Done() <-chan struct{} {
+	return s.done
+}
+
+// Info returns a JSON-serializable snapshot of the session's metadata.
+// The snapshot is taken under the session's lock to ensure consistency.
+func (s *Session) Info() SessionInfo {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return SessionInfo{
+		ID:        s.ID,
+		Title:     s.Title,
+		Status:    s.Status,
+		CreatedAt: s.CreatedAt,
+		PID:       s.PID,
+		ExitCode:  s.ExitCode,
+	}
+}
+
+// BufferData returns a copy of all data currently stored in the ring buffer,
+// ordered from oldest to newest. This is used for reconnect replay.
+func (s *Session) BufferData() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ringBuf.ReadAll()
+}
+
+// ---------------------------------------------------------------------------
+// ringBuffer — a fixed-capacity circular buffer that implements io.Writer.
+// When the buffer is full, new writes overwrite the oldest data.
+// ---------------------------------------------------------------------------
+
+// ringBuffer is a fixed-size circular byte buffer. It stores the most recent
+// N bytes of data, silently discarding older content when capacity is exceeded.
+type ringBuffer struct {
+	buf  []byte // backing storage
+	size int    // capacity (len(buf))
+	w    int    // next write position
+	full bool   // true once the buffer has wrapped at least once
+}
+
+// Compile-time check that ringBuffer implements io.Writer.
+var _ io.Writer = (*ringBuffer)(nil)
+
+// newRingBuffer allocates a ring buffer with the given capacity.
+// A capacity of zero or negative is clamped to 1 to avoid panics.
+func newRingBuffer(size int) *ringBuffer {
+	if size <= 0 {
+		size = 1
+	}
+	return &ringBuffer{
+		buf:  make([]byte, size),
+		size: size,
+	}
+}
+
+// Write appends p to the ring buffer. If p is larger than the buffer's
+// capacity, only the last `size` bytes of p are retained. Write always
+// returns len(p), nil — it never fails.
+func (rb *ringBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	if n == 0 {
+		return 0, nil
+	}
+
+	// If the incoming data is larger than the entire buffer, only keep
+	// the trailing portion that fits.
+	if n >= rb.size {
+		copy(rb.buf, p[n-rb.size:])
+		rb.w = 0
+		rb.full = true
+		return n, nil
+	}
+
+	// How many bytes fit before we wrap?
+	remaining := rb.size - rb.w
+	if n <= remaining {
+		// Fits without wrapping.
+		copy(rb.buf[rb.w:], p)
+		rb.w += n
+		if rb.w == rb.size {
+			rb.w = 0
+			rb.full = true
+		}
+	} else {
+		// Split write: fill to end, then wrap to beginning.
+		copy(rb.buf[rb.w:], p[:remaining])
+		copy(rb.buf, p[remaining:])
+		rb.w = n - remaining
+		rb.full = true
+	}
+
+	return n, nil
+}
+
+// ReadAll returns a copy of all buffered data, ordered oldest to newest.
+// If the buffer has never wrapped, this is buf[0:w].
+// If wrapped, the result is buf[w:] + buf[:w] (oldest portion first).
+func (rb *ringBuffer) ReadAll() []byte {
+	if !rb.full {
+		out := make([]byte, rb.w)
+		copy(out, rb.buf[:rb.w])
+		return out
+	}
+
+	out := make([]byte, rb.size)
+	// Oldest data starts at the write position.
+	firstLen := rb.size - rb.w
+	copy(out, rb.buf[rb.w:])
+	copy(out[firstLen:], rb.buf[:rb.w])
+	return out
+}


### PR DESCRIPTION
## Summary

Implements the Go daemon's core session layer and PTY management (Issue #1, M1 foundation).

- **`daemon/config/`** — Config struct with 4-layer priority: hardcoded defaults < `~/.zplex/config.toml` < env vars (`ZPLEX_PORT`, `ZPLEX_SHELL`) < CLI flags (`--port`, `--shell`)
- **`daemon/session/`** — `Session` struct wrapping go-pty with ring buffer (102KB default) for reconnect replay; `SessionManager` providing Create/Get/List/Kill/Shutdown CRUD
- **`daemon/main.go`** — Entry point: load config → create SessionManager → block on SIGINT/SIGTERM → graceful shutdown
- **ConPTY fix** — Windows ConPTY doesn't return EOF on natural process exit; solved by running `cmd.Wait()` in a separate goroutine that closes the PTY to unblock Read, protected by `sync.Once`

## Key Design Decisions

- Ring buffer is internal to the session package (unexported `ringBuffer` type) — keeps the public API minimal
- Session IDs use `crypto/rand` hex encoding (`s-` prefix + 16 hex chars) for uniqueness without external dependencies
- PTY double-close prevented by `sync.Once` — necessary because both `readLoop`'s Wait goroutine and `Close()` may attempt to close the PTY

## Test Plan

- [x] 9 ring buffer tests (empty, basic, multiple writes, exact capacity, overflow, wrap-around, zero capacity, return value, empty write)
- [x] 2 session PTY tests (create + I/O with echo verification, Info() metadata)
- [x] 1 natural exit detection test (shell `exit` → Status="exited", ExitCode=0)
- [x] 1 Close()-driven exit test (Kill → Done channel closed, Status="exited")
- [x] 3 manager CRUD tests (full lifecycle, multiple sessions, shutdown)
- [x] All 16 tests pass on Windows with ConPTY (`go test ./session/ -v`)

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
