### PR TITLE
feat: add HTTP server + WebSocket PTY I/O relay

### DIFF
--- a/daemon/go.mod
+++ b/daemon/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/BurntSushi/toml v1.5.0
 	github.com/aymanbagabas/go-pty v0.2.2
+	github.com/gorilla/websocket v1.5.3
 )
 
 require (

--- a/daemon/go.sum
+++ b/daemon/go.sum
@@ -4,6 +4,8 @@ github.com/aymanbagabas/go-pty v0.2.2 h1:YZREB4eSj+1xdbbItIokX0ekjjeifgJOA+ZvxU4
 github.com/aymanbagabas/go-pty v0.2.2/go.mod h1:gfvlwH+0U66BCwxJREjJaAOEs9H1OFf3YFjI9WSiZ04=
 github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
 github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/u-root/gobusybox/src v0.0.0-20221229083637-46b2883a7f90 h1:zTk5683I9K62wtZ6eUa6vu6IWwVHXPnoKK5n2unAwv0=
 github.com/u-root/gobusybox/src v0.0.0-20221229083637-46b2883a7f90/go.mod h1:lYt+LVfZBBwDZ3+PHk4k/c/TnKOkjJXiJO73E32Mmpc=
 github.com/u-root/u-root v0.11.0 h1:6gCZLOeRyevw7gbTwMj3fKxnr9+yHFlgF3N7udUVNO8=

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/zac15987/zplex/daemon/config"
+	"github.com/zac15987/zplex/daemon/server"
 	"github.com/zac15987/zplex/daemon/session"
 )
 
@@ -20,6 +25,25 @@ func main() {
 
 	// Create SessionManager with config-driven defaults.
 	mgr := session.NewSessionManager(cfg.DefaultShell, cfg.BufferSize)
+
+	// Build the HTTP/WebSocket server wired to the session manager.
+	srv := server.NewServer(mgr)
+
+	httpServer := &http.Server{
+		Addr:    fmt.Sprintf(":%d", cfg.Port),
+		Handler: srv.Handler(),
+	}
+
+	// Start the HTTP server in a background goroutine.
+	go func() {
+		slog.Info("zplex daemon listening",
+			slog.String("addr", httpServer.Addr),
+		)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("HTTP server error", slog.String("error", err.Error()))
+			os.Exit(1)
+		}
+	}()
 
 	slog.Info("zplex daemon started",
 		slog.Int("port", cfg.Port),
@@ -36,7 +60,16 @@ func main() {
 	sig := <-sigCh
 	slog.Info("received shutdown signal", slog.String("signal", sig.String()))
 
-	// Graceful shutdown — close every PTY session.
+	// Graceful shutdown: stop accepting new connections (5s timeout),
+	// then close all PTY sessions.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		slog.Error("HTTP server shutdown error", slog.String("error", err.Error()))
+	}
+	slog.Info("HTTP server stopped")
+
 	mgr.Shutdown()
 	slog.Info("zplex daemon stopped")
 }

--- a/daemon/server/api.go
+++ b/daemon/server/api.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Health endpoint
+// ---------------------------------------------------------------------------
+
+// healthResponse is the JSON payload returned by GET /api/health.
+type healthResponse struct {
+	Status   string `json:"status"`
+	Version  string `json:"version"`
+	Uptime   int    `json:"uptime"`
+	Sessions int    `json:"sessions"`
+}
+
+// handleHealth responds with daemon health information including version,
+// uptime in seconds, and the number of active sessions.
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	slog.Info("server.handleHealth: processing health check")
+
+	uptimeSeconds := int(time.Since(s.startTime).Seconds())
+	sessionCount := len(s.mgr.List())
+
+	resp := healthResponse{
+		Status:   "ok",
+		Version:  s.version,
+		Uptime:   uptimeSeconds,
+		Sessions: sessionCount,
+	}
+
+	slog.Info("server.handleHealth: health check complete",
+		slog.Int("uptime", uptimeSeconds),
+		slog.Int("sessions", sessionCount),
+	)
+
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// ---------------------------------------------------------------------------
+// JSON response helpers
+// ---------------------------------------------------------------------------
+
+// writeJSON serializes v as JSON and writes it to w with the given HTTP status
+// code. If serialization fails, it falls back to a 500 error.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("server.writeJSON: failed to encode response",
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// errorResponse is the JSON payload used by writeError.
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+// writeError writes a JSON error response with the given HTTP status code and
+// human-readable message.
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, errorResponse{Error: message})
+}

--- a/daemon/server/api.go
+++ b/daemon/server/api.go
@@ -2,9 +2,12 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/zac15987/zplex/daemon/session"
 )
 
 // ---------------------------------------------------------------------------
@@ -25,7 +28,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	slog.Info("server.handleHealth: processing health check")
 
 	uptimeSeconds := int(time.Since(s.startTime).Seconds())
-	sessionCount := len(s.mgr.List())
+	sessionCount := s.mgr.Count()
 
 	resp := healthResponse{
 		Status:   "ok",
@@ -40,6 +43,182 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	)
 
 	writeJSON(w, http.StatusOK, resp)
+}
+
+// ---------------------------------------------------------------------------
+// Session CRUD endpoints
+// ---------------------------------------------------------------------------
+
+// handleListSessions responds with a JSON array of all active sessions.
+// An empty manager returns [] (not null).
+func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
+	slog.Info("server.handleListSessions: listing sessions")
+
+	infos := s.mgr.List()
+
+	slog.Info("server.handleListSessions: returning sessions",
+		slog.Int("count", len(infos)),
+	)
+
+	writeJSON(w, http.StatusOK, infos)
+}
+
+// createSessionRequest is the JSON body accepted by POST /api/sessions.
+type createSessionRequest struct {
+	Shell string   `json:"shell"`
+	Title string   `json:"title"`
+	Args  []string `json:"args,omitempty"` // reserved for future use
+	Cwd   string   `json:"cwd,omitempty"`  // reserved for future use
+	Env   []string `json:"env,omitempty"`  // reserved for future use
+	Cols  int      `json:"cols"`
+	Rows  int      `json:"rows"`
+}
+
+// createSessionResponse is the JSON payload returned by POST /api/sessions.
+type createSessionResponse struct {
+	ID    string `json:"id"`
+	WsURL string `json:"ws_url"`
+}
+
+// handleCreateSession creates a new PTY-backed session. Both shell and title
+// are required in the request body.
+func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
+	slog.Info("server.handleCreateSession: processing create request")
+
+	var req createSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		slog.Warn("server.handleCreateSession: invalid request body",
+			slog.String("error", err.Error()),
+		)
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.Shell == "" {
+		slog.Warn("server.handleCreateSession: missing required field 'shell'")
+		writeError(w, http.StatusBadRequest, "missing required field: shell")
+		return
+	}
+	if req.Title == "" {
+		slog.Warn("server.handleCreateSession: missing required field 'title'")
+		writeError(w, http.StatusBadRequest, "missing required field: title")
+		return
+	}
+
+	sess, err := s.mgr.CreateSession(session.CreateOptions{
+		Shell: req.Shell,
+		Title: req.Title,
+		Cols:  req.Cols,
+		Rows:  req.Rows,
+	})
+	if err != nil {
+		slog.Error("server.handleCreateSession: failed to create session",
+			slog.String("error", err.Error()),
+		)
+		writeError(w, http.StatusInternalServerError, "failed to create session")
+		return
+	}
+
+	slog.Info("server.handleCreateSession: session created",
+		slog.String("session_id", sess.ID),
+	)
+
+	writeJSON(w, http.StatusCreated, createSessionResponse{
+		ID:    sess.ID,
+		WsURL: "/ws/" + sess.ID,
+	})
+}
+
+// handleGetSession responds with full details for a single session.
+func (s *Server) handleGetSession(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	slog.Info("server.handleGetSession: looking up session",
+		slog.String("session_id", id),
+	)
+
+	sess, err := s.mgr.Get(id)
+	if err != nil {
+		if errors.Is(err, session.ErrSessionNotFound) {
+			writeError(w, http.StatusNotFound, "session not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to get session")
+		return
+	}
+
+	slog.Info("server.handleGetSession: returning session",
+		slog.String("session_id", id),
+	)
+
+	writeJSON(w, http.StatusOK, sess.Info())
+}
+
+// handleDeleteSession kills a session and removes it from the manager.
+func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	slog.Info("server.handleDeleteSession: deleting session",
+		slog.String("session_id", id),
+	)
+
+	if err := s.mgr.Kill(id); err != nil {
+		if errors.Is(err, session.ErrSessionNotFound) {
+			writeError(w, http.StatusNotFound, "session not found")
+			return
+		}
+		slog.Error("server.handleDeleteSession: failed to kill session",
+			slog.String("session_id", id),
+			slog.String("error", err.Error()),
+		)
+		writeError(w, http.StatusInternalServerError, "failed to kill session")
+		return
+	}
+
+	slog.Info("server.handleDeleteSession: session deleted",
+		slog.String("session_id", id),
+	)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// patchSessionRequest is the JSON body accepted by PATCH /api/sessions/{id}.
+type patchSessionRequest struct {
+	Title  string `json:"title"`
+	Status string `json:"status"`
+}
+
+// handlePatchSession updates mutable metadata on an existing session.
+func (s *Server) handlePatchSession(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	slog.Info("server.handlePatchSession: updating session",
+		slog.String("session_id", id),
+	)
+
+	sess, err := s.mgr.Get(id)
+	if err != nil {
+		if errors.Is(err, session.ErrSessionNotFound) {
+			writeError(w, http.StatusNotFound, "session not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to get session")
+		return
+	}
+
+	var req patchSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		slog.Warn("server.handlePatchSession: invalid request body",
+			slog.String("error", err.Error()),
+		)
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	sess.UpdateMeta(req.Title, req.Status)
+
+	slog.Info("server.handlePatchSession: session updated",
+		slog.String("session_id", id),
+	)
+
+	writeJSON(w, http.StatusOK, sess.Info())
 }
 
 // ---------------------------------------------------------------------------

--- a/daemon/server/api_test.go
+++ b/daemon/server/api_test.go
@@ -1,0 +1,499 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/zac15987/zplex/daemon/session"
+)
+
+// newTestServer creates a Server backed by a real SessionManager for
+// integration testing. The test server and manager are torn down
+// automatically when the test finishes.
+func newTestServer(t *testing.T) (*Server, *httptest.Server) {
+	t.Helper()
+	mgr := session.NewSessionManager("powershell", 102400)
+	srv := NewServer(mgr)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(func() {
+		ts.Close()
+		mgr.Shutdown()
+	})
+	return srv, ts
+}
+
+// wsURL converts an httptest.Server URL to a WebSocket URL for the given path.
+func wsURL(ts *httptest.Server, path string) string {
+	return "ws" + strings.TrimPrefix(ts.URL, "http") + path
+}
+
+// createTestSession creates a session via the REST API and returns its ID.
+// It fails the test immediately if the request or response is malformed.
+func createTestSession(t *testing.T, ts *httptest.Server, title string) string {
+	t.Helper()
+
+	body := `{"shell":"powershell","title":"` + title + `"}`
+	resp, err := http.Post(ts.URL+"/api/sessions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("createTestSession: POST failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("createTestSession: expected 201, got %d", resp.StatusCode)
+	}
+
+	var result createSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("createTestSession: decode failed: %v", err)
+	}
+	if result.ID == "" {
+		t.Fatal("createTestSession: returned empty session ID")
+	}
+	return result.ID
+}
+
+// ---------------------------------------------------------------------------
+// Health endpoint
+// ---------------------------------------------------------------------------
+
+func TestHealthEndpoint(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	resp, err := http.Get(ts.URL + "/api/health")
+	if err != nil {
+		t.Fatalf("GET /api/health failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+
+	var body healthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode health response: %v", err)
+	}
+
+	if body.Status != "ok" {
+		t.Errorf("expected status %q, got %q", "ok", body.Status)
+	}
+	if body.Version != "0.1.0" {
+		t.Errorf("expected version %q, got %q", "0.1.0", body.Version)
+	}
+	if body.Uptime < 0 {
+		t.Errorf("expected uptime >= 0, got %d", body.Uptime)
+	}
+	if body.Sessions < 0 {
+		t.Errorf("expected sessions >= 0, got %d", body.Sessions)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session listing
+// ---------------------------------------------------------------------------
+
+func TestListSessions_Empty(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	resp, err := http.Get(ts.URL + "/api/sessions")
+	if err != nil {
+		t.Fatalf("GET /api/sessions failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	// Decode into a raw JSON array to verify it is [] and not null.
+	var raw json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed != "[]" {
+		t.Errorf("expected empty array [], got %s", trimmed)
+	}
+}
+
+func TestListSessions_AfterCreate(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	createTestSession(t, ts, "list-test-1")
+	createTestSession(t, ts, "list-test-2")
+
+	resp, err := http.Get(ts.URL + "/api/sessions")
+	if err != nil {
+		t.Fatalf("GET /api/sessions failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var infos []session.SessionInfo
+	if err := json.NewDecoder(resp.Body).Decode(&infos); err != nil {
+		t.Fatalf("failed to decode sessions list: %v", err)
+	}
+
+	if len(infos) != 2 {
+		t.Errorf("expected 2 sessions, got %d", len(infos))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session creation
+// ---------------------------------------------------------------------------
+
+func TestCreateSession_Success(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	body := `{"shell":"powershell","title":"create-test"}`
+	resp, err := http.Post(ts.URL+"/api/sessions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/sessions failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	var result createSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
+
+	if result.ID == "" {
+		t.Error("expected non-empty session ID")
+	}
+	if !strings.HasPrefix(result.WsURL, "/ws/") {
+		t.Errorf("expected ws_url to start with /ws/, got %q", result.WsURL)
+	}
+}
+
+func TestCreateSession_MissingFields(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing shell", body: `{"title":"test"}`},
+		{name: "missing title", body: `{"shell":"powershell"}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := http.Post(ts.URL+"/api/sessions", "application/json", strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatalf("POST /api/sessions failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("expected status 400, got %d", resp.StatusCode)
+			}
+
+			var errResp errorResponse
+			if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+				t.Fatalf("failed to decode error response: %v", err)
+			}
+			if errResp.Error == "" {
+				t.Error("expected non-empty error message")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session get
+// ---------------------------------------------------------------------------
+
+func TestGetSession_Success(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	sessionID := createTestSession(t, ts, "get-test")
+
+	resp, err := http.Get(ts.URL + "/api/sessions/" + sessionID)
+	if err != nil {
+		t.Fatalf("GET /api/sessions/%s failed: %v", sessionID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var info session.SessionInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		t.Fatalf("failed to decode session info: %v", err)
+	}
+
+	if info.ID != sessionID {
+		t.Errorf("expected ID %q, got %q", sessionID, info.ID)
+	}
+	if info.Title != "get-test" {
+		t.Errorf("expected title %q, got %q", "get-test", info.Title)
+	}
+	if info.Status != "running" {
+		t.Errorf("expected status %q, got %q", "running", info.Status)
+	}
+}
+
+func TestGetSession_NotFound(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	resp, err := http.Get(ts.URL + "/api/sessions/nonexistent")
+	if err != nil {
+		t.Fatalf("GET /api/sessions/nonexistent failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session delete
+// ---------------------------------------------------------------------------
+
+func TestDeleteSession_Success(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	sessionID := createTestSession(t, ts, "delete-test")
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/api/sessions/"+sessionID, nil)
+	if err != nil {
+		t.Fatalf("failed to create DELETE request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE /api/sessions/%s failed: %v", sessionID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("expected status 204, got %d", resp.StatusCode)
+	}
+
+	// Subsequent GET should return 404.
+	getResp, err := http.Get(ts.URL + "/api/sessions/" + sessionID)
+	if err != nil {
+		t.Fatalf("GET after delete failed: %v", err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 after delete, got %d", getResp.StatusCode)
+	}
+}
+
+func TestDeleteSession_NotFound(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/api/sessions/nonexistent", nil)
+	if err != nil {
+		t.Fatalf("failed to create DELETE request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE /api/sessions/nonexistent failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session patch
+// ---------------------------------------------------------------------------
+
+func TestPatchSession_Success(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	sessionID := createTestSession(t, ts, "patch-test")
+
+	patchBody := `{"title":"patched title"}`
+	req, err := http.NewRequest(http.MethodPatch, ts.URL+"/api/sessions/"+sessionID, strings.NewReader(patchBody))
+	if err != nil {
+		t.Fatalf("failed to create PATCH request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH /api/sessions/%s failed: %v", sessionID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var info session.SessionInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		t.Fatalf("failed to decode patched session: %v", err)
+	}
+
+	if info.Title != "patched title" {
+		t.Errorf("expected title %q, got %q", "patched title", info.Title)
+	}
+}
+
+func TestPatchSession_NotFound(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	patchBody := `{"title":"will not work"}`
+	req, err := http.NewRequest(http.MethodPatch, ts.URL+"/api/sessions/nonexistent", strings.NewReader(patchBody))
+	if err != nil {
+		t.Fatalf("failed to create PATCH request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH /api/sessions/nonexistent failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket — connect and I/O relay
+// ---------------------------------------------------------------------------
+
+func TestWebSocket_ConnectAndIO(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	sessionID := createTestSession(t, ts, "ws-io-test")
+
+	// Allow the shell to start up before connecting.
+	time.Sleep(2 * time.Second)
+
+	dialer := websocket.Dialer{}
+	conn, _, err := dialer.Dial(wsURL(ts, "/ws/"+sessionID), nil)
+	if err != nil {
+		t.Fatalf("WebSocket dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	// Send a command that produces recognizable output. We do this
+	// immediately — any replay data or prompt output is harmless and
+	// will be read alongside the echo output in the loop below.
+	inputMsg := wsMessage{Type: "input", Data: "echo hello-ws-test\r\n"}
+	if err := conn.WriteJSON(inputMsg); err != nil {
+		t.Fatalf("failed to send input message: %v", err)
+	}
+
+	// Read output messages until we see the echo string or timeout.
+	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	found := false
+	for {
+		_, raw, readErr := conn.ReadMessage()
+		if readErr != nil {
+			break
+		}
+		if strings.Contains(string(raw), "hello-ws-test") {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("expected to see 'hello-ws-test' in WebSocket output")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket — resize
+// ---------------------------------------------------------------------------
+
+func TestWebSocket_Resize(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	sessionID := createTestSession(t, ts, "ws-resize-test")
+
+	time.Sleep(1 * time.Second)
+
+	dialer := websocket.Dialer{}
+	conn, _, err := dialer.Dial(wsURL(ts, "/ws/"+sessionID), nil)
+	if err != nil {
+		t.Fatalf("WebSocket dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	// Send a resize message.
+	resizeMsg := wsMessage{Type: "resize", Cols: 120, Rows: 40}
+	if err := conn.WriteJSON(resizeMsg); err != nil {
+		t.Fatalf("failed to send resize message: %v", err)
+	}
+
+	// Resize is fire-and-forget; verify the connection is still alive by
+	// reading at least one message (prompt output) or timing out gracefully.
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, _, readErr := conn.ReadMessage()
+	// A timeout is acceptable — the resize succeeded without error.
+	if readErr != nil && !isTimeoutError(readErr) {
+		t.Errorf("unexpected error after resize: %v", readErr)
+	}
+}
+
+// isTimeoutError checks whether an error is a network timeout.
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// net.Error has a Timeout() method.
+	type timeouter interface {
+		Timeout() bool
+	}
+	if te, ok := err.(timeouter); ok {
+		return te.Timeout()
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket — not found
+// ---------------------------------------------------------------------------
+
+func TestWebSocket_NotFound(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	dialer := websocket.Dialer{}
+	_, resp, err := dialer.Dial(wsURL(ts, "/ws/nonexistent-id"), nil)
+	if err == nil {
+		t.Fatal("expected WebSocket dial to fail for nonexistent session")
+	}
+
+	if resp == nil {
+		t.Fatal("expected non-nil HTTP response on dial failure")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", resp.StatusCode)
+	}
+}

--- a/daemon/server/router.go
+++ b/daemon/server/router.go
@@ -3,7 +3,10 @@
 package server
 
 import (
+	"bufio"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"regexp"
 	"time"
@@ -99,6 +102,16 @@ type responseWriter struct {
 func (rw *responseWriter) WriteHeader(code int) {
 	rw.statusCode = code
 	rw.ResponseWriter.WriteHeader(code)
+}
+
+// Hijack delegates to the underlying ResponseWriter's Hijack method if it
+// implements http.Hijacker. This is required for WebSocket upgrades, which
+// need to take over the raw TCP connection.
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := rw.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, fmt.Errorf("underlying ResponseWriter does not implement http.Hijacker")
 }
 
 // loggingMiddleware logs every HTTP request with method, path, status code,

--- a/daemon/server/router.go
+++ b/daemon/server/router.go
@@ -51,6 +51,8 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("DELETE /api/sessions/{id}", s.handleDeleteSession)
 	mux.HandleFunc("PATCH /api/sessions/{id}", s.handlePatchSession)
 
+	mux.HandleFunc("GET /ws/{session_id}", s.handleWebSocket)
+
 	// Middleware chain: CORS wraps logging wraps routing.
 	return corsMiddleware(loggingMiddleware(mux))
 }

--- a/daemon/server/router.go
+++ b/daemon/server/router.go
@@ -45,6 +45,11 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /api/health", s.handleHealth)
+	mux.HandleFunc("GET /api/sessions", s.handleListSessions)
+	mux.HandleFunc("POST /api/sessions", s.handleCreateSession)
+	mux.HandleFunc("GET /api/sessions/{id}", s.handleGetSession)
+	mux.HandleFunc("DELETE /api/sessions/{id}", s.handleDeleteSession)
+	mux.HandleFunc("PATCH /api/sessions/{id}", s.handlePatchSession)
 
 	// Middleware chain: CORS wraps logging wraps routing.
 	return corsMiddleware(loggingMiddleware(mux))

--- a/daemon/server/router.go
+++ b/daemon/server/router.go
@@ -1,0 +1,113 @@
+// Package server implements the HTTP API layer for the zplex daemon.
+// It provides REST endpoints, CORS middleware, and request logging.
+package server
+
+import (
+	"log/slog"
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/zac15987/zplex/daemon/session"
+)
+
+// localhostOriginPattern matches http://localhost with an optional port.
+var localhostOriginPattern = regexp.MustCompile(`^http://localhost(:\d+)?$`)
+
+// allowedMethods lists the HTTP methods permitted in CORS preflight responses.
+const allowedMethods = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+
+// allowedHeaders lists the request headers permitted in CORS preflight responses.
+const allowedHeaders = "Content-Type, Authorization"
+
+// Server holds references shared by all HTTP handlers.
+type Server struct {
+	mgr       *session.SessionManager
+	startTime time.Time
+	version   string
+}
+
+// NewServer creates a Server wired to the given session manager. The returned
+// Server exposes a Handler() method that produces a fully-configured
+// http.Handler (mux + middleware).
+func NewServer(mgr *session.SessionManager) *Server {
+	slog.Info("server.NewServer: initializing HTTP server")
+	return &Server{
+		mgr:       mgr,
+		startTime: time.Now(),
+		version:   "0.1.0",
+	}
+}
+
+// Handler builds the HTTP handler chain: routes -> logging -> CORS.
+// The outermost middleware executes first on each request.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("GET /api/health", s.handleHealth)
+
+	// Middleware chain: CORS wraps logging wraps routing.
+	return corsMiddleware(loggingMiddleware(mux))
+}
+
+// ---------------------------------------------------------------------------
+// CORS middleware
+// ---------------------------------------------------------------------------
+
+// corsMiddleware adds CORS headers for http://localhost:* origins and handles
+// OPTIONS preflight requests. Requests from non-localhost origins are served
+// normally but without CORS headers.
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		origin := r.Header.Get("Origin")
+
+		if localhostOriginPattern.MatchString(origin) {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", allowedMethods)
+			w.Header().Set("Access-Control-Allow-Headers", allowedHeaders)
+
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Logging middleware
+// ---------------------------------------------------------------------------
+
+// responseWriter wraps http.ResponseWriter to capture the status code written
+// by downstream handlers so the logging middleware can report it.
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+// WriteHeader captures the status code before delegating to the underlying
+// ResponseWriter.
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// loggingMiddleware logs every HTTP request with method, path, status code,
+// and duration.
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+		next.ServeHTTP(rw, r)
+
+		slog.Info("server: request completed",
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.Int("status", rw.statusCode),
+			slog.Duration("duration", time.Since(start)),
+		)
+	})
+}

--- a/daemon/server/ws.go
+++ b/daemon/server/ws.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 
@@ -98,30 +97,20 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 
-	// Step 2: Writer goroutine — reads live PTY output and forwards to WebSocket.
+	// Step 2: Writer goroutine — subscribes to live PTY output from the
+	// session's readLoop and forwards each chunk to the WebSocket client.
+	outputCh := sess.Subscribe()
 	writerDone := make(chan struct{})
 	go func() {
 		defer close(writerDone)
-		buf := make([]byte, 4096)
-		for {
-			n, readErr := sess.Read(buf)
-			if n > 0 {
-				msg := wsOutputMessage{Type: "output", Data: string(buf[:n])}
-				if writeErr := conn.WriteJSON(msg); writeErr != nil {
-					slog.Debug("server.handleWebSocket: write to WS failed",
-						slog.String("session_id", sessionID),
-						slog.String("error", writeErr.Error()),
-					)
-					return
-				}
-			}
-			if readErr != nil {
-				if readErr != io.EOF {
-					slog.Debug("server.handleWebSocket: PTY read ended",
-						slog.String("session_id", sessionID),
-						slog.String("error", readErr.Error()),
-					)
-				}
+		defer sess.Unsubscribe(outputCh)
+		for data := range outputCh {
+			msg := wsOutputMessage{Type: "output", Data: string(data)}
+			if writeErr := conn.WriteJSON(msg); writeErr != nil {
+				slog.Debug("server.handleWebSocket: write to WS failed",
+					slog.String("session_id", sessionID),
+					slog.String("error", writeErr.Error()),
+				)
 				return
 			}
 		}

--- a/daemon/server/ws.go
+++ b/daemon/server/ws.go
@@ -1,0 +1,201 @@
+package server
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+	"github.com/zac15987/zplex/daemon/session"
+)
+
+// upgrader upgrades HTTP connections to WebSocket. The origin check allows
+// localhost origins (for Electron dev mode) and requests with no Origin header
+// (e.g., curl, Postman). Non-localhost origins are rejected.
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  4096,
+	WriteBufferSize: 4096,
+	CheckOrigin: func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		return localhostOriginPattern.MatchString(origin) || origin == ""
+	},
+}
+
+// wsMessage is the envelope for all client-to-server WebSocket messages.
+type wsMessage struct {
+	Type string `json:"type"`
+	Data string `json:"data,omitempty"`
+	Cols int    `json:"cols,omitempty"`
+	Rows int    `json:"rows,omitempty"`
+}
+
+// wsOutputMessage is sent server-to-client with PTY output.
+type wsOutputMessage struct {
+	Type string `json:"type"`
+	Data string `json:"data"`
+}
+
+// wsExitMessage is sent server-to-client when the PTY process exits.
+type wsExitMessage struct {
+	Type string `json:"type"`
+	Code int    `json:"code"`
+}
+
+// handleWebSocket upgrades an HTTP request to a WebSocket connection and relays
+// I/O between the WebSocket client and the session's PTY. On connect, any data
+// in the session's ring buffer is replayed to the client so that a reconnecting
+// frontend sees recent output.
+//
+// Concurrency contract for gorilla/websocket:
+//   - The writer goroutine is the only goroutine that calls conn.WriteJSON.
+//     The exit monitor waits for writerDone before sending its exit message.
+//   - The main goroutine (reader loop) is the only goroutine that calls
+//     conn.ReadJSON.
+func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("session_id")
+
+	// Look up session BEFORE upgrading so we can return a proper HTTP error
+	// (404) instead of completing the handshake and immediately closing.
+	sess, err := s.mgr.Get(sessionID)
+	if err != nil {
+		if errors.Is(err, session.ErrSessionNotFound) {
+			writeError(w, http.StatusNotFound, "session not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to get session")
+		return
+	}
+
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		slog.Error("server.handleWebSocket: upgrade failed",
+			slog.String("session_id", sessionID),
+			slog.String("error", err.Error()),
+		)
+		return // Upgrade already wrote the error response
+	}
+	defer conn.Close()
+
+	slog.Info("server.handleWebSocket: client connected",
+		slog.String("session_id", sessionID),
+	)
+
+	// Step 1: Replay ring buffer content so reconnecting clients see recent output.
+	replayData := sess.BufferData()
+	if len(replayData) > 0 {
+		msg := wsOutputMessage{Type: "output", Data: string(replayData)}
+		if err := conn.WriteJSON(msg); err != nil {
+			slog.Error("server.handleWebSocket: replay failed",
+				slog.String("session_id", sessionID),
+				slog.String("error", err.Error()),
+			)
+			return
+		}
+		slog.Info("server.handleWebSocket: replay sent",
+			slog.String("session_id", sessionID),
+			slog.Int("bytes", len(replayData)),
+		)
+	}
+
+	// Step 2: Writer goroutine — reads live PTY output and forwards to WebSocket.
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := sess.Read(buf)
+			if n > 0 {
+				msg := wsOutputMessage{Type: "output", Data: string(buf[:n])}
+				if writeErr := conn.WriteJSON(msg); writeErr != nil {
+					slog.Debug("server.handleWebSocket: write to WS failed",
+						slog.String("session_id", sessionID),
+						slog.String("error", writeErr.Error()),
+					)
+					return
+				}
+			}
+			if readErr != nil {
+				if readErr != io.EOF {
+					slog.Debug("server.handleWebSocket: PTY read ended",
+						slog.String("session_id", sessionID),
+						slog.String("error", readErr.Error()),
+					)
+				}
+				return
+			}
+		}
+	}()
+
+	// Step 3: Exit monitor — waits for the session to exit, then sends the
+	// exit message after the writer goroutine has drained. This avoids
+	// concurrent WriteJSON calls.
+	go func() {
+		select {
+		case <-sess.Done():
+			// Wait for the writer goroutine to finish draining PTY output
+			// before sending the exit message. This ensures the client
+			// receives all output before the exit notification.
+			<-writerDone
+			info := sess.Info()
+			exitMsg := wsExitMessage{Type: "exit", Code: info.ExitCode}
+			if err := conn.WriteJSON(exitMsg); err != nil {
+				slog.Debug("server.handleWebSocket: exit message write failed",
+					slog.String("session_id", sessionID),
+					slog.String("error", err.Error()),
+				)
+			}
+			conn.Close()
+		case <-writerDone:
+			// Writer exited for another reason (WS write error, etc.)
+			return
+		}
+	}()
+
+	// Step 4: Reader loop — reads client messages and dispatches to PTY.
+	// This runs in the current goroutine (the HTTP handler goroutine).
+	for {
+		var msg wsMessage
+		if err := conn.ReadJSON(&msg); err != nil {
+			if websocket.IsUnexpectedCloseError(err,
+				websocket.CloseNormalClosure,
+				websocket.CloseGoingAway) {
+				slog.Warn("server.handleWebSocket: unexpected close",
+					slog.String("session_id", sessionID),
+					slog.String("error", err.Error()),
+				)
+			}
+			break
+		}
+
+		switch msg.Type {
+		case "input":
+			if _, err := sess.Write([]byte(msg.Data)); err != nil {
+				slog.Warn("server.handleWebSocket: PTY write failed",
+					slog.String("session_id", sessionID),
+					slog.String("error", err.Error()),
+				)
+			}
+		case "resize":
+			if msg.Cols > 0 && msg.Rows > 0 {
+				if err := sess.Resize(msg.Cols, msg.Rows); err != nil {
+					slog.Warn("server.handleWebSocket: resize failed",
+						slog.String("session_id", sessionID),
+						slog.Int("cols", msg.Cols),
+						slog.Int("rows", msg.Rows),
+						slog.String("error", err.Error()),
+					)
+				}
+			}
+		default:
+			slog.Warn("server.handleWebSocket: unknown message type",
+				slog.String("session_id", sessionID),
+				slog.String("type", msg.Type),
+			)
+		}
+	}
+
+	slog.Info("server.handleWebSocket: client disconnected",
+		slog.String("session_id", sessionID),
+	)
+}

--- a/daemon/session/manager.go
+++ b/daemon/session/manager.go
@@ -60,6 +60,67 @@ func (m *SessionManager) Create(title string) (*Session, error) {
 	return sess, nil
 }
 
+// CreateOptions holds parameters for creating a new session.
+type CreateOptions struct {
+	Shell string
+	Title string
+	Cols  int
+	Rows  int
+}
+
+// CreateSession spawns a new PTY-backed session with the given options.
+// If Shell is empty, the manager's default shell is used.
+// If Cols/Rows are non-zero, the PTY is resized after creation.
+func (m *SessionManager) CreateSession(opts CreateOptions) (*Session, error) {
+	slog.Info("manager.CreateSession: creating session",
+		slog.String("title", opts.Title),
+		slog.String("shell", opts.Shell),
+		slog.Int("cols", opts.Cols),
+		slog.Int("rows", opts.Rows),
+	)
+
+	shell := opts.Shell
+	if shell == "" {
+		shell = m.shell
+	}
+
+	id := "s-" + generateID()
+
+	sess, err := NewSession(id, opts.Title, shell, m.bufferSize)
+	if err != nil {
+		slog.Error("manager.CreateSession: failed to create session",
+			slog.String("title", opts.Title),
+			slog.String("error", err.Error()),
+		)
+		return nil, err
+	}
+
+	// Resize if cols/rows specified.
+	if opts.Cols > 0 && opts.Rows > 0 {
+		if err := sess.Resize(opts.Cols, opts.Rows); err != nil {
+			slog.Warn("manager.CreateSession: failed to resize session",
+				slog.String("session_id", id),
+				slog.String("error", err.Error()),
+			)
+			// Non-fatal: session is still usable at default size.
+		}
+	}
+
+	m.mu.Lock()
+	m.sessions[id] = sess
+	m.mu.Unlock()
+
+	slog.Info("manager.CreateSession: session created", slog.String("session_id", id))
+	return sess, nil
+}
+
+// Count returns the number of active sessions.
+func (m *SessionManager) Count() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.sessions)
+}
+
 // Get returns the session with the given ID. If no session exists for that ID,
 // it returns ErrSessionNotFound.
 func (m *SessionManager) Get(id string) (*Session, error) {

--- a/daemon/session/session.go
+++ b/daemon/session/session.go
@@ -225,6 +225,35 @@ func (s *Session) Info() SessionInfo {
 	}
 }
 
+// Resize changes the PTY window size. It delegates to the underlying PTY's
+// Resize method. This is called when the frontend sends a resize message.
+func (s *Session) Resize(cols, rows int) error {
+	slog.Info("session.Resize: resizing PTY",
+		slog.String("session_id", s.ID),
+		slog.Int("cols", cols),
+		slog.Int("rows", rows),
+	)
+	return s.pty.Resize(cols, rows)
+}
+
+// UpdateMeta updates the session's mutable metadata fields.
+// Empty strings are ignored (only non-empty values are applied).
+func (s *Session) UpdateMeta(title, status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if title != "" {
+		s.Title = title
+	}
+	if status != "" {
+		s.Status = status
+	}
+	slog.Info("session.UpdateMeta: metadata updated",
+		slog.String("session_id", s.ID),
+		slog.String("title", s.Title),
+		slog.String("status", s.Status),
+	)
+}
+
 // BufferData returns a copy of all data currently stored in the ring buffer,
 // ordered from oldest to newest. This is used for reconnect replay.
 func (s *Session) BufferData() []byte {

--- a/daemon/session/session.go
+++ b/daemon/session/session.go
@@ -36,9 +36,14 @@ type Session struct {
 	pty      pty.Pty     // PTY handle (ConPTY on Windows, /dev/ptmx on Unix)
 	cmd      *pty.Cmd    // the running subprocess
 	ringBuf  *ringBuffer // circular buffer for replay
-	mu       sync.Mutex  // protects Status, ExitCode, ringBuf writes
+	mu       sync.Mutex  // protects Status, ExitCode, ringBuf writes, subscribers
 	done     chan struct{}
 	closePTY sync.Once // ensures PTY is closed exactly once
+
+	// subscribers receive copies of live PTY output from the readLoop.
+	// Each subscriber is a buffered channel; slow consumers are skipped
+	// to avoid blocking the readLoop.
+	subscribers []chan []byte
 }
 
 // readBufSize is the size of the temporary buffer used when reading PTY output
@@ -138,8 +143,24 @@ func (s *Session) readLoop() {
 	for {
 		n, err := s.pty.Read(buf)
 		if n > 0 {
+			// Make a copy for subscribers before taking the lock so we
+			// can send without holding the mutex longer than needed.
+			data := make([]byte, n)
+			copy(data, buf[:n])
+
 			s.mu.Lock()
-			s.ringBuf.Write(buf[:n])
+			s.ringBuf.Write(data)
+			for _, sub := range s.subscribers {
+				select {
+				case sub <- data:
+				default:
+					// Subscriber too slow — drop this chunk to avoid
+					// blocking the readLoop.
+					slog.Warn("session.readLoop: dropped output for slow subscriber",
+						slog.String("session_id", s.ID),
+					)
+				}
+			}
 			s.mu.Unlock()
 		}
 		if err != nil {
@@ -156,6 +177,15 @@ func (s *Session) readLoop() {
 	// Wait for the cmd.Wait goroutine to finish capturing exit state.
 	<-waitDone
 
+	// Close all subscriber channels so that consumers (e.g., WebSocket
+	// writer goroutines using range) terminate cleanly.
+	s.mu.Lock()
+	for _, sub := range s.subscribers {
+		close(sub)
+	}
+	s.subscribers = nil
+	s.mu.Unlock()
+
 	close(s.done)
 
 	slog.Info("session.readLoop: session fully stopped",
@@ -163,9 +193,52 @@ func (s *Session) readLoop() {
 	)
 }
 
-// Read reads PTY output directly. This is the primary interface for
-// WebSocket consumers that forward live output to the frontend.
-// The ring buffer is populated separately by the background goroutine.
+// subscriberBufSize is the channel buffer size for output subscribers.
+// A generous buffer prevents the readLoop from dropping data for
+// subscribers that are briefly slow.
+const subscriberBufSize = 256
+
+// Subscribe returns a channel that receives copies of live PTY output.
+// The caller must call Unsubscribe when done to avoid resource leaks.
+// Each message on the channel is an independent byte slice that the
+// subscriber owns (safe to retain).
+func (s *Session) Subscribe() chan []byte {
+	ch := make(chan []byte, subscriberBufSize)
+	s.mu.Lock()
+	s.subscribers = append(s.subscribers, ch)
+	s.mu.Unlock()
+	slog.Info("session.Subscribe: subscriber added",
+		slog.String("session_id", s.ID),
+	)
+	return ch
+}
+
+// Unsubscribe removes a subscriber channel and closes it. After this call
+// the channel will receive no further messages. If the session has already
+// exited (readLoop closed all subscribers), this is a safe no-op.
+func (s *Session) Unsubscribe(ch chan []byte) {
+	s.mu.Lock()
+	for i, sub := range s.subscribers {
+		if sub == ch {
+			s.subscribers = append(s.subscribers[:i], s.subscribers[i+1:]...)
+			close(ch)
+			s.mu.Unlock()
+			slog.Info("session.Unsubscribe: subscriber removed",
+				slog.String("session_id", s.ID),
+			)
+			return
+		}
+	}
+	s.mu.Unlock()
+	// Channel was already closed by readLoop on session exit — nothing to do.
+	slog.Info("session.Unsubscribe: subscriber already removed (session exited)",
+		slog.String("session_id", s.ID),
+	)
+}
+
+// Read reads PTY output directly. This is a low-level interface; prefer
+// Subscribe for WebSocket consumers that need live output without competing
+// with the background readLoop.
 func (s *Session) Read(p []byte) (int, error) {
 	return s.pty.Read(p)
 }


### PR DESCRIPTION
## Summary

- Add `daemon/server/` package with HTTP REST API and WebSocket handler for PTY I/O relay
- **REST endpoints**: `GET /api/health`, session CRUD (`GET/POST /api/sessions`, `GET/DELETE/PATCH /api/sessions/{id}`)
- **WebSocket** `/ws/{session_id}`: ring buffer replay on connect, bidirectional PTY I/O (input/resize client→server, output/exit server→client)
- **CORS middleware** allowing `http://localhost:*` origins for Electron dev mode
- **Logging middleware** with method, path, status code, duration via `log/slog`
- **main.go** wired with HTTP server startup and graceful shutdown (HTTP 5s timeout → SessionManager shutdown)
- **Subscriber pattern** added to session.readLoop for fan-out PTY output to multiple WebSocket clients without read races
- **gorilla/websocket v1.5.3** added as dependency; all routing via Go stdlib `net/http.ServeMux`

## Changes

| File | Action |
|------|--------|
| `daemon/server/router.go` | New — HTTP mux, CORS middleware, logging middleware, Hijack support |
| `daemon/server/api.go` | New — REST handlers (health + session CRUD) + JSON helpers |
| `daemon/server/ws.go` | New — WebSocket handler with PTY relay + ring buffer replay |
| `daemon/server/api_test.go` | New — 14 integration tests (REST + WebSocket) |
| `daemon/main.go` | Modified — HTTP server startup + graceful shutdown sequence |
| `daemon/session/session.go` | Modified — Added Resize, UpdateMeta, Subscribe/Unsubscribe methods |
| `daemon/session/manager.go` | Modified — Added CreateSession (with options), Count method |
| `daemon/go.mod` | Modified — Added gorilla/websocket v1.5.3 |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./server/ -v` — all 14 tests pass (health, session CRUD status codes, WebSocket connect/IO/resize/404)
- [x] `go test ./session/` — existing session tests still pass
- [x] Manual: start daemon, curl health endpoint, create session via REST, connect via wscat

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
