### PR TITLE
Frontend: multi-panel auto-tiled CSS Grid layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,25 @@ Go Daemon (single binary, port 17732)
   → ring buffer (100KB default) per session for reconnect replay
 ```
 
+### Multi-Panel Layout
+
+The frontend uses an auto-tiled CSS Grid layout engine (`app/src/layout.ts`) that manages terminal panels dynamically:
+
+- **PanelGrid class** (`layout.ts`): Manages panel placement, gutter resize, and focus tracking.
+- **Auto-tile algorithm**: Panels auto-arrange in 1-2 rows. Columns = ceil(N/2). Bottom row panels span to fill width when fewer than top row.
+- **Maximum 8 panels** per workspace. Attempts to add more are silently ignored with a console warning.
+- **Workspace-scoped registry**: Sessions are organized as `Map<workspaceId, Map<sessionId, TerminalWrapper>>` in `app.ts`. Current default workspace is `"default"`.
+- **Gutter drag resize**: Panels can be resized by dragging gutter bars between them. Minimum panel size: 120px wide, 80px tall.
+
+### Keyboard Shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+Shift+N` | Create new terminal panel |
+| `Ctrl+Shift+W` | Close focused panel (shows dialog or uses saved preference) |
+| `Ctrl+Shift+Arrow` | Move focus to adjacent panel (Up/Down/Left/Right) |
+| `Shift+Click [×]` | Force close dialog (override saved preference) |
+
 ### Daemon REST API
 
 | Method | Path | Purpose |

--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -219,7 +219,7 @@ function refitAllTerminals(): void {
  * Show the close confirmation dialog and return the user's choice.
  * Returns null if cancelled.
  */
-function showCloseDialog(): Promise<CloseDialogResult | null> {
+function showCloseDialog(savedPreference?: ClosePreference): Promise<CloseDialogResult | null> {
   return new Promise<CloseDialogResult | null>((resolve) => {
     const dialog = document.getElementById("close-dialog") as HTMLDialogElement | null;
     if (!dialog) {
@@ -235,7 +235,12 @@ function showCloseDialog(): Promise<CloseDialogResult | null> {
     const cancelBtn = document.getElementById("close-cancel");
     const confirmBtn = document.getElementById("close-confirm");
 
-    if (detachRadio) detachRadio.checked = true;
+    // Pre-select saved preference if available (for Shift+click override)
+    if (savedPreference === "kill" && killRadio) {
+      killRadio.checked = true;
+    } else if (detachRadio) {
+      detachRadio.checked = true;
+    }
     if (rememberCheckbox) rememberCheckbox.checked = false;
 
     // Clean up function to remove listeners
@@ -320,17 +325,18 @@ async function executeClose(sessionId: string, action: ClosePreference): Promise
 async function closePanelFlow(sessionId: string, forceDialog: boolean): Promise<void> {
   console.warn("[app] closePanelFlow entry:", sessionId, "forceDialog:", forceDialog);
 
-  // Check for saved preference (AC-9)
-  if (!forceDialog) {
-    const saved = localStorage.getItem(CLOSE_PREFERENCE_KEY) as ClosePreference | null;
-    if (saved === "detach" || saved === "kill") {
-      await executeClose(sessionId, saved);
-      return;
-    }
+  // Read saved preference once for both skip-dialog and pre-select paths
+  const saved = localStorage.getItem(CLOSE_PREFERENCE_KEY) as ClosePreference | null;
+  const validSaved = (saved === "detach" || saved === "kill") ? saved : undefined;
+
+  // Use saved preference directly if not forcing dialog (AC-9)
+  if (!forceDialog && validSaved) {
+    await executeClose(sessionId, validSaved);
+    return;
   }
 
-  // Show dialog (AC-8)
-  const result = await showCloseDialog();
+  // Show dialog, pre-selecting saved preference if available (AC-10)
+  const result = await showCloseDialog(validSaved);
   if (!result) {
     // User cancelled
     console.warn("[app] closePanelFlow cancelled by user");

--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -172,6 +172,19 @@ function mountSessionToGrid(sessionId: string, title: string): void {
     wrapper.focusTerminal();
   });
 
+  // Wire up close button [x] (AC-8, AC-10)
+  const closeBtn = panelInfo.headerElement.querySelector(".panel-close-btn");
+  if (closeBtn) {
+    closeBtn.addEventListener("click", (e: Event) => {
+      const mouseEvent = e as MouseEvent;
+      // Shift+click forces dialog even if preference is saved (AC-10)
+      const forceDialog = mouseEvent.shiftKey;
+      closePanelFlow(sessionId, forceDialog).catch((err: unknown) => {
+        console.error("[app] close panel failed:", err);
+      });
+    });
+  }
+
   // Set focus on the newly created panel
   panelGrid.setFocus(sessionId);
   wrapper.focusTerminal();
@@ -196,6 +209,168 @@ function refitAllTerminals(): void {
       }
     }
   });
+}
+
+// ---------------------------------------------------------------------------
+// Close panel flow
+// ---------------------------------------------------------------------------
+
+/**
+ * Show the close confirmation dialog and return the user's choice.
+ * Returns null if cancelled.
+ */
+function showCloseDialog(): Promise<CloseDialogResult | null> {
+  return new Promise<CloseDialogResult | null>((resolve) => {
+    const dialog = document.getElementById("close-dialog") as HTMLDialogElement | null;
+    if (!dialog) {
+      console.error("[app] close-dialog element not found");
+      resolve(null);
+      return;
+    }
+
+    // Reset dialog state
+    const detachRadio = document.getElementById("close-detach") as HTMLInputElement | null;
+    const killRadio = document.getElementById("close-kill") as HTMLInputElement | null;
+    const rememberCheckbox = document.getElementById("close-remember") as HTMLInputElement | null;
+    const cancelBtn = document.getElementById("close-cancel");
+    const confirmBtn = document.getElementById("close-confirm");
+
+    if (detachRadio) detachRadio.checked = true;
+    if (rememberCheckbox) rememberCheckbox.checked = false;
+
+    // Clean up function to remove listeners
+    const cleanup = (): void => {
+      dialog.close();
+      cancelBtn?.removeEventListener("click", onCancel);
+      confirmBtn?.removeEventListener("click", onConfirm);
+    };
+
+    const onCancel = (): void => {
+      cleanup();
+      resolve(null);
+    };
+
+    const onConfirm = (): void => {
+      const action: ClosePreference = killRadio?.checked ? "kill" : "detach";
+      const remember = rememberCheckbox?.checked ?? false;
+      cleanup();
+      resolve({ action, remember });
+    };
+
+    cancelBtn?.addEventListener("click", onCancel);
+    confirmBtn?.addEventListener("click", onConfirm);
+
+    dialog.showModal();
+  });
+}
+
+/**
+ * Execute the close action on a panel: remove from grid, dispose terminal,
+ * and optionally kill the daemon session.
+ */
+async function executeClose(sessionId: string, action: ClosePreference): Promise<void> {
+  console.warn("[app] executeClose entry:", sessionId, "action:", action);
+
+  // Kill session on daemon if requested
+  if (action === "kill") {
+    try {
+      await apiDelete(`/api/sessions/${sessionId}`);
+      console.warn("[app] session killed on daemon:", sessionId);
+    } catch (err: unknown) {
+      console.error("[app] failed to kill session:", sessionId, err);
+    }
+  }
+
+  // Dispose terminal wrapper
+  const registry = getWorkspaceRegistry(DEFAULT_WORKSPACE_ID);
+  const wrapper = registry.get(sessionId);
+  if (wrapper) {
+    wrapper.dispose();
+    registry.delete(sessionId);
+  }
+
+  // Remove panel from grid
+  if (panelGrid) {
+    panelGrid.removePanel(sessionId);
+
+    // Auto-focus the next available panel
+    const remainingIds = panelGrid.getPanelIds();
+    if (remainingIds.length > 0) {
+      const nextId = remainingIds[remainingIds.length - 1];
+      panelGrid.setFocus(nextId);
+      const nextWrapper = registry.get(nextId);
+      if (nextWrapper) {
+        nextWrapper.focusTerminal();
+      }
+    }
+  }
+
+  // Refit remaining terminals after layout change
+  refitAllTerminals();
+
+  console.warn("[app] executeClose exit:", sessionId);
+}
+
+/**
+ * Initiate the close flow for a panel.
+ *
+ * If a saved preference exists and forceDialog is false, skip the dialog.
+ * Otherwise show the HTML <dialog> element for user choice.
+ */
+async function closePanelFlow(sessionId: string, forceDialog: boolean): Promise<void> {
+  console.warn("[app] closePanelFlow entry:", sessionId, "forceDialog:", forceDialog);
+
+  // Check for saved preference (AC-9)
+  if (!forceDialog) {
+    const saved = localStorage.getItem(CLOSE_PREFERENCE_KEY) as ClosePreference | null;
+    if (saved === "detach" || saved === "kill") {
+      await executeClose(sessionId, saved);
+      return;
+    }
+  }
+
+  // Show dialog (AC-8)
+  const result = await showCloseDialog();
+  if (!result) {
+    // User cancelled
+    console.warn("[app] closePanelFlow cancelled by user");
+    return;
+  }
+
+  // Save preference if requested (AC-9)
+  if (result.remember) {
+    localStorage.setItem(CLOSE_PREFERENCE_KEY, result.action);
+    console.warn("[app] close preference saved:", result.action);
+  }
+
+  await executeClose(sessionId, result.action);
+
+  console.warn("[app] closePanelFlow exit:", sessionId);
+}
+
+// ---------------------------------------------------------------------------
+// Focus navigation
+// ---------------------------------------------------------------------------
+
+/**
+ * Move focus to the adjacent panel in the given direction.
+ * If no adjacent panel exists, focus stays on the current panel.
+ */
+function moveFocus(direction: "up" | "down" | "left" | "right"): void {
+  if (!panelGrid) return;
+
+  const currentId = panelGrid.getFocusedPanelId();
+  if (!currentId) return;
+
+  const adjacentId = panelGrid.getAdjacentPanelId(currentId, direction);
+  if (!adjacentId) return;
+
+  panelGrid.setFocus(adjacentId);
+  const registry = getWorkspaceRegistry(DEFAULT_WORKSPACE_ID);
+  const wrapper = registry.get(adjacentId);
+  if (wrapper) {
+    wrapper.focusTerminal();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -234,6 +409,61 @@ async function init(): Promise<void> {
       });
     });
   }
+
+  // Keyboard shortcuts (AC-5, AC-6, AC-7)
+  document.addEventListener("keydown", (e: KeyboardEvent) => {
+    // All shortcuts require Ctrl+Shift
+    if (!e.ctrlKey || !e.shiftKey) {
+      return;
+    }
+
+    switch (e.key) {
+      // Ctrl+Shift+N: New panel (AC-5)
+      case "N":
+      case "n": {
+        e.preventDefault();
+        createAndMountPanel().catch((err: unknown) => {
+          console.error("[app] failed to create panel via shortcut:", err);
+        });
+        break;
+      }
+
+      // Ctrl+Shift+W: Close focused panel (AC-6)
+      case "W":
+      case "w": {
+        e.preventDefault();
+        const focusedId = panelGrid?.getFocusedPanelId();
+        if (focusedId) {
+          closePanelFlow(focusedId, false).catch((err: unknown) => {
+            console.error("[app] failed to close panel via shortcut:", err);
+          });
+        }
+        break;
+      }
+
+      // Ctrl+Shift+Arrow: Move focus (AC-7)
+      case "ArrowUp": {
+        e.preventDefault();
+        moveFocus("up");
+        break;
+      }
+      case "ArrowDown": {
+        e.preventDefault();
+        moveFocus("down");
+        break;
+      }
+      case "ArrowLeft": {
+        e.preventDefault();
+        moveFocus("left");
+        break;
+      }
+      case "ArrowRight": {
+        e.preventDefault();
+        moveFocus("right");
+        break;
+      }
+    }
+  });
 
   // Fetch existing sessions and reconnect
   const sessionList = await apiGet<SessionInfo[]>("/api/sessions");

--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -1,36 +1,62 @@
 /**
- * App entry point -- manages session lifecycle.
+ * App entry point -- manages session lifecycle and multi-panel layout.
  *
  * On DOM ready:
- *   1. Fetch existing sessions from the daemon (GET /api/sessions).
- *   2. If a running session exists, reconnect to it (ring buffer replay).
- *   3. Otherwise, create a new session (POST /api/sessions) and mount it.
+ *   1. Initialize PanelGrid on the grid-container element.
+ *   2. Fetch existing sessions from the daemon (GET /api/sessions).
+ *   3. Reconnect to all running sessions (ring buffer replay), or create one.
+ *   4. Wire up the "+" button for spawning additional panels.
  *
- * Maintains a session registry (Map<string, TerminalWrapper>) that is ready
- * for multi-panel expansion in M2 without refactoring.
+ * Sessions are organized in a workspace-scoped registry:
+ *   Map<workspaceId, Map<sessionId, TerminalWrapper>>
  */
 
 import { TerminalWrapper } from "./terminal";
+import { PanelGrid } from "./layout";
 import type {
   SessionInfo,
   CreateSessionRequest,
   CreateSessionResponse,
+  ClosePreference,
+  CloseDialogResult,
 } from "./types";
 
 // ---------------------------------------------------------------------------
-// Session registry
-// ---------------------------------------------------------------------------
-
-/** Maps session ID to its TerminalWrapper. Supports future multi-panel. */
-const sessions = new Map<string, TerminalWrapper>();
-
-// ---------------------------------------------------------------------------
-// Daemon communication helpers
+// Constants
 // ---------------------------------------------------------------------------
 
 const DEFAULT_DAEMON_PORT = 17732;
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
+const DEFAULT_WORKSPACE_ID = "default";
+const CLOSE_PREFERENCE_KEY = "zplex:closePreference";
+
+// ---------------------------------------------------------------------------
+// Workspace-scoped session registry
+// ---------------------------------------------------------------------------
+
+/** Workspace-scoped session registry: Map<workspaceId, Map<sessionId, TerminalWrapper>> */
+const workspaces = new Map<string, Map<string, TerminalWrapper>>();
+
+/** Get or create the session map for a workspace. */
+function getWorkspaceRegistry(workspaceId: string): Map<string, TerminalWrapper> {
+  let registry = workspaces.get(workspaceId);
+  if (!registry) {
+    registry = new Map<string, TerminalWrapper>();
+    workspaces.set(workspaceId, registry);
+  }
+  return registry;
+}
+
+// ---------------------------------------------------------------------------
+// Grid instance
+// ---------------------------------------------------------------------------
+
+let panelGrid: PanelGrid | null = null;
+
+// ---------------------------------------------------------------------------
+// Daemon communication helpers
+// ---------------------------------------------------------------------------
 
 /** Resolve the daemon port from the preload bridge, falling back to default. */
 function getDaemonPort(): number {
@@ -63,25 +89,113 @@ async function apiPost<TReq, TRes>(path: string, body: TReq): Promise<TRes> {
   return resp.json() as Promise<TRes>;
 }
 
+/** Fire-and-forget DELETE against the daemon REST API. */
+async function apiDelete(path: string): Promise<void> {
+  const port = getDaemonPort();
+  const resp = await fetch(`http://localhost:${port}${path}`, { method: "DELETE" });
+  if (!resp.ok) {
+    throw new Error(`DELETE ${path} failed: ${resp.status} ${resp.statusText}`);
+  }
+}
+
 // ---------------------------------------------------------------------------
-// Terminal mounting
+// Panel creation and mounting
 // ---------------------------------------------------------------------------
 
 /**
- * Create a TerminalWrapper for the given session, mount it into the DOM
- * container, and register it in the session map.
+ * Create a new session on the daemon, add a panel to the grid, mount an xterm
+ * instance into it, and register everything.
  */
-function mountTerminal(sessionId: string): TerminalWrapper {
-  const port = getDaemonPort();
-  const container = document.getElementById("terminal-container");
-  if (!container) {
-    throw new Error("terminal-container element not found in DOM");
+async function createAndMountPanel(title?: string): Promise<void> {
+  console.warn("[app] createAndMountPanel entry");
+
+  if (!panelGrid) {
+    console.error("[app] panelGrid not initialized");
+    return;
   }
 
+  // Create session on daemon
+  const request: CreateSessionRequest = {
+    shell: "pwsh", // Uses daemon's default_shell in production
+    title: title ?? `Terminal ${panelGrid.getPanelCount() + 1}`,
+    cols: DEFAULT_COLS,
+    rows: DEFAULT_ROWS,
+  };
+
+  const result = await apiPost<CreateSessionRequest, CreateSessionResponse>(
+    "/api/sessions",
+    request,
+  );
+
+  mountSessionToGrid(result.id, request.title);
+
+  console.warn("[app] createAndMountPanel exit, session:", result.id);
+}
+
+/**
+ * Add a panel to the grid for an existing session, mount xterm, and wire up
+ * focus/dispose callbacks.
+ */
+function mountSessionToGrid(sessionId: string, title: string): void {
+  console.warn("[app] mountSessionToGrid entry:", sessionId);
+
+  if (!panelGrid) {
+    console.error("[app] panelGrid not initialized");
+    return;
+  }
+
+  const panelInfo = panelGrid.addPanel(sessionId, title, DEFAULT_WORKSPACE_ID);
+  if (!panelInfo) {
+    // Max panels reached
+    return;
+  }
+
+  const port = getDaemonPort();
   const wrapper = new TerminalWrapper(sessionId, port);
-  wrapper.mount(container);
-  sessions.set(sessionId, wrapper);
-  return wrapper;
+
+  // Register focus callback: when terminal is clicked, set panel focus
+  wrapper.onFocus((id: string) => {
+    panelGrid?.setFocus(id);
+    wrapper.focusTerminal();
+  });
+
+  // Register in workspace registry
+  const registry = getWorkspaceRegistry(DEFAULT_WORKSPACE_ID);
+  registry.set(sessionId, wrapper);
+
+  // Mount xterm into the panel's content area
+  wrapper.mount(panelInfo.contentElement);
+
+  // Wire up header click-to-focus
+  panelInfo.headerElement.addEventListener("mousedown", () => {
+    panelGrid?.setFocus(sessionId);
+    wrapper.focusTerminal();
+  });
+
+  // Set focus on the newly created panel
+  panelGrid.setFocus(sessionId);
+  wrapper.focusTerminal();
+
+  console.warn("[app] mountSessionToGrid exit:", sessionId);
+}
+
+// ---------------------------------------------------------------------------
+// Terminal re-fit
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-fit all terminal instances to their containers.
+ * Called after panel add/remove/resize to update xterm dimensions.
+ */
+function refitAllTerminals(): void {
+  // Use requestAnimationFrame to ensure DOM has settled
+  requestAnimationFrame(() => {
+    for (const [, registry] of workspaces) {
+      for (const [, wrapper] of registry) {
+        wrapper.fit();
+      }
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -90,38 +204,53 @@ function mountTerminal(sessionId: string): TerminalWrapper {
 
 /**
  * Core initialization sequence:
- *   - Query daemon for existing sessions.
- *   - Reconnect to the first running session, or create a new one.
+ *   - Create PanelGrid on the grid-container element.
+ *   - Wire up resize and "+" button callbacks.
+ *   - Reconnect to all running sessions, or create a new one.
  */
 async function init(): Promise<void> {
+  console.warn("[app] init entry");
   const port = getDaemonPort();
-  console.warn("[app] initializing, daemon port:", port);
+  console.warn("[app] daemon port:", port);
 
-  // Fetch existing sessions from the daemon.
-  const sessionList = await apiGet<SessionInfo[]>("/api/sessions");
-  const runningSession = sessionList.find((s) => s.status === "running");
-
-  if (runningSession) {
-    // Reconnect -- the daemon's ring buffer will replay recent output (AC-9).
-    console.warn("[app] reconnecting to session:", runningSession.id);
-    mountTerminal(runningSession.id);
-  } else {
-    // No running session -- create a fresh one (AC-5).
-    // Use default 80x24; FitAddon sends correct dimensions after mount.
-    console.warn("[app] no running sessions, creating new session");
-    const request: CreateSessionRequest = {
-      shell: "pwsh",
-      title: "Terminal",
-      cols: DEFAULT_COLS,
-      rows: DEFAULT_ROWS,
-    };
-    const result = await apiPost<CreateSessionRequest, CreateSessionResponse>(
-      "/api/sessions",
-      request,
-    );
-    console.warn("[app] session created:", result.id);
-    mountTerminal(result.id);
+  // Initialize the grid
+  const container = document.getElementById("grid-container");
+  if (!container) {
+    throw new Error("grid-container element not found in DOM");
   }
+  panelGrid = new PanelGrid(container);
+
+  // Register resize callback for FitAddon
+  panelGrid.onPanelResize(() => {
+    refitAllTerminals();
+  });
+
+  // Wire up the "+" button
+  const addBtn = document.getElementById("add-panel-btn");
+  if (addBtn) {
+    addBtn.addEventListener("click", () => {
+      createAndMountPanel().catch((err: unknown) => {
+        console.error("[app] failed to create panel:", err);
+      });
+    });
+  }
+
+  // Fetch existing sessions and reconnect
+  const sessionList = await apiGet<SessionInfo[]>("/api/sessions");
+  const runningSessions = sessionList.filter((s) => s.status === "running");
+
+  if (runningSessions.length > 0) {
+    console.warn("[app] reconnecting to", runningSessions.length, "running sessions");
+    for (const session of runningSessions) {
+      mountSessionToGrid(session.id, session.title);
+    }
+  } else {
+    // No running sessions — create a fresh one
+    console.warn("[app] no running sessions, creating initial session");
+    await createAndMountPanel("Terminal 1");
+  }
+
+  console.warn("[app] init exit");
 }
 
 // ---------------------------------------------------------------------------

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -8,7 +8,35 @@
   <link rel="stylesheet" href="./styles.css">
 </head>
 <body>
-  <div id="terminal-container"></div>
+  <!-- Grid container: panels and gutters are inserted dynamically by layout.ts -->
+  <div id="grid-container"></div>
+
+  <!-- Add panel button (AC-13) -->
+  <button id="add-panel-btn" title="New panel (Ctrl+Shift+N)">+</button>
+
+  <!-- Close confirmation dialog (AC-8) -->
+  <dialog id="close-dialog">
+    <div class="dialog-title">Close Panel</div>
+    <div class="dialog-options">
+      <div class="dialog-option">
+        <input type="radio" name="close-action" id="close-detach" value="detach" checked>
+        <label for="close-detach">僅關閉 UI（Session 繼續背景執行）</label>
+      </div>
+      <div class="dialog-option">
+        <input type="radio" name="close-action" id="close-kill" value="kill">
+        <label for="close-kill">結束 Session（終止 PTY 程序）</label>
+      </div>
+    </div>
+    <div class="dialog-remember">
+      <input type="checkbox" id="close-remember">
+      <label for="close-remember">記住我的選擇</label>
+    </div>
+    <div class="dialog-actions">
+      <button class="dialog-btn" id="close-cancel">取消</button>
+      <button class="dialog-btn dialog-btn-primary" id="close-confirm">確定</button>
+    </div>
+  </dialog>
+
   <script type="module" src="./app.ts"></script>
 </body>
 </html>

--- a/app/src/layout.ts
+++ b/app/src/layout.ts
@@ -1,0 +1,460 @@
+/**
+ * CSS Grid panel layout engine.
+ *
+ * PanelGrid manages an auto-tiled grid of terminal panels. Given N panels
+ * (1-8), it computes a 1- or 2-row grid layout and places panels using
+ * explicit CSS Grid column/row assignments. Gutter elements are inserted
+ * between adjacent panels to support future drag-resize (T6).
+ *
+ * Grid structure example (5 panels = 3 top + 2 bottom):
+ *   grid-template-columns: 1fr 4px 1fr 4px 1fr
+ *   grid-template-rows:    1fr 4px 1fr
+ *   Top row panels occupy grid columns 1, 3, 5 at grid row 1.
+ *   Bottom row panels span proportionally across all 5 CSS columns at row 3.
+ */
+
+import type { PanelInfo, GridConfig } from "./types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_PANELS = 8;
+const MIN_PANEL_WIDTH = 120;
+const MIN_PANEL_HEIGHT = 80;
+const GUTTER_SIZE_PX = 4;
+
+// ---------------------------------------------------------------------------
+// Auto-tile algorithm
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute grid dimensions for a given panel count.
+ *
+ * Layout rules:
+ *   - 1-2 panels: single row
+ *   - 3-8 panels: two rows; top row gets ceil(N/2), bottom gets remainder
+ */
+export function computeGridConfig(panelCount: number): GridConfig {
+  const clamped = Math.max(0, Math.min(panelCount, MAX_PANELS));
+  const rows = clamped <= 2 ? 1 : 2;
+  const columns = clamped <= 2 ? clamped : Math.ceil(clamped / 2);
+  const topRowCount = clamped <= 2 ? clamped : columns;
+  const bottomRowCount = clamped <= 2 ? 0 : clamped - columns;
+
+  return { columns, rows, topRowCount, bottomRowCount };
+}
+
+// ---------------------------------------------------------------------------
+// PanelGrid class
+// ---------------------------------------------------------------------------
+
+export class PanelGrid {
+  private readonly container: HTMLElement;
+
+  /** Ordered array of session IDs — determines grid placement order. */
+  private readonly panelOrder: string[] = [];
+
+  /** Maps session ID to its PanelInfo. */
+  private readonly panelMap: Map<string, PanelInfo> = new Map();
+
+  /** Currently focused panel, or null. */
+  private focusedPanelId: string | null = null;
+
+  /** Current grid configuration (recomputed on every rebuildGrid call). */
+  private currentConfig: GridConfig = { columns: 0, rows: 0, topRowCount: 0, bottomRowCount: 0 };
+
+  /** Column sizes — initially empty; populated by rebuildGrid. */
+  private columnSizes: number[] = [];
+
+  /** Row sizes — initially empty; populated by rebuildGrid. */
+  private rowSizes: number[] = [];
+
+  constructor(containerElement: HTMLElement) {
+    this.container = containerElement;
+  }
+
+  // -------------------------------------------------------------------------
+  // Public methods
+  // -------------------------------------------------------------------------
+
+  /**
+   * Add a new panel to the grid.
+   *
+   * Returns the created PanelInfo, or null if the grid is at capacity.
+   */
+  addPanel(sessionId: string, title: string, workspaceId: string): PanelInfo | null {
+    console.warn("[layout] addPanel entry:", sessionId);
+
+    if (this.panelOrder.length >= MAX_PANELS) {
+      console.warn("[layout] max panel count (8) reached, ignoring new panel request");
+      return null;
+    }
+
+    // Build DOM structure: div.panel > (div.panel-header, div.panel-content)
+    const element = document.createElement("div");
+    element.classList.add("panel");
+    element.dataset.sessionId = sessionId;
+
+    const headerElement = document.createElement("div");
+    headerElement.classList.add("panel-header");
+
+    const titleSpan = document.createElement("span");
+    titleSpan.classList.add("panel-title");
+    titleSpan.textContent = title;
+
+    const closeBtn = document.createElement("button");
+    closeBtn.classList.add("panel-close-btn");
+    closeBtn.textContent = "\u00d7"; // multiplication sign (x)
+
+    headerElement.appendChild(titleSpan);
+    headerElement.appendChild(closeBtn);
+
+    const contentElement = document.createElement("div");
+    contentElement.classList.add("panel-content");
+
+    element.appendChild(headerElement);
+    element.appendChild(contentElement);
+
+    const panelInfo: PanelInfo = {
+      sessionId,
+      title,
+      workspaceId,
+      element,
+      headerElement,
+      contentElement,
+    };
+
+    this.panelOrder.push(sessionId);
+    this.panelMap.set(sessionId, panelInfo);
+    this.rebuildGrid();
+
+    console.warn("[layout] addPanel exit:", sessionId);
+    return panelInfo;
+  }
+
+  /** Remove a panel from the grid by session ID. */
+  removePanel(sessionId: string): void {
+    console.warn("[layout] removePanel entry:", sessionId);
+
+    const panel = this.panelMap.get(sessionId);
+    if (!panel) {
+      console.warn("[layout] removePanel: session not found:", sessionId);
+      return;
+    }
+
+    // Remove DOM element from container (if currently attached)
+    if (panel.element.parentNode === this.container) {
+      this.container.removeChild(panel.element);
+    }
+
+    this.panelMap.delete(sessionId);
+    const idx = this.panelOrder.indexOf(sessionId);
+    if (idx !== -1) {
+      this.panelOrder.splice(idx, 1);
+    }
+
+    // Clear focus if the removed panel was focused
+    if (this.focusedPanelId === sessionId) {
+      this.focusedPanelId = null;
+    }
+
+    this.rebuildGrid();
+
+    console.warn("[layout] removePanel exit:", sessionId);
+  }
+
+  /** Set focus on a panel, removing focus from all others. */
+  setFocus(sessionId: string): void {
+    console.warn("[layout] setFocus:", sessionId);
+
+    // Remove .focused from all panels
+    for (const panel of this.panelMap.values()) {
+      panel.element.classList.remove("focused");
+    }
+
+    const target = this.panelMap.get(sessionId);
+    if (target) {
+      target.element.classList.add("focused");
+      this.focusedPanelId = sessionId;
+    }
+  }
+
+  /** Return the currently focused panel's session ID, or null. */
+  getFocusedPanelId(): string | null {
+    return this.focusedPanelId;
+  }
+
+  /** Return the ordered array of panel session IDs. */
+  getPanelIds(): readonly string[] {
+    return this.panelOrder;
+  }
+
+  /** Look up a panel by session ID. */
+  getPanelInfo(sessionId: string): PanelInfo | undefined {
+    return this.panelMap.get(sessionId);
+  }
+
+  /** Return the current number of panels. */
+  getPanelCount(): number {
+    return this.panelOrder.length;
+  }
+
+  /**
+   * Find the adjacent panel in a given direction from the specified panel.
+   *
+   * Grid position is derived from the panel's index in the ordered array:
+   *   - Top row: indices 0..topRowCount-1
+   *   - Bottom row: indices topRowCount..N-1
+   *
+   * Returns null if there is no adjacent panel in that direction.
+   */
+  getAdjacentPanelId(
+    fromSessionId: string,
+    direction: "up" | "down" | "left" | "right",
+  ): string | null {
+    const idx = this.panelOrder.indexOf(fromSessionId);
+    if (idx === -1) {
+      return null;
+    }
+
+    const config = this.currentConfig;
+    const { topRowCount, bottomRowCount } = config;
+    const isTopRow = idx < topRowCount;
+    const rowIndex = isTopRow ? 0 : 1;
+    const colInRow = isTopRow ? idx : idx - topRowCount;
+    const rowLength = isTopRow ? topRowCount : bottomRowCount;
+
+    switch (direction) {
+      case "left": {
+        if (colInRow <= 0) {
+          return null;
+        }
+        const targetIdx = isTopRow ? colInRow - 1 : topRowCount + colInRow - 1;
+        return this.panelOrder[targetIdx] ?? null;
+      }
+      case "right": {
+        if (colInRow >= rowLength - 1) {
+          return null;
+        }
+        const targetIdx = isTopRow ? colInRow + 1 : topRowCount + colInRow + 1;
+        return this.panelOrder[targetIdx] ?? null;
+      }
+      case "up": {
+        if (rowIndex === 0) {
+          return null;
+        }
+        // Moving up from bottom row: find closest column in top row
+        const targetCol = Math.min(
+          Math.round((colInRow / bottomRowCount) * topRowCount),
+          topRowCount - 1,
+        );
+        return this.panelOrder[targetCol] ?? null;
+      }
+      case "down": {
+        if (rowIndex === 1 || bottomRowCount === 0) {
+          return null;
+        }
+        // Moving down from top row: find closest column in bottom row
+        const targetCol = Math.min(
+          Math.round((colInRow / topRowCount) * bottomRowCount),
+          bottomRowCount - 1,
+        );
+        return this.panelOrder[topRowCount + targetCol] ?? null;
+      }
+    }
+  }
+
+  /** Return the current grid configuration. */
+  getGridConfig(): GridConfig {
+    return { ...this.currentConfig };
+  }
+
+  /** Return current column sizes (fr or px values). */
+  getColumnSizes(): number[] {
+    return [...this.columnSizes];
+  }
+
+  /** Return current row sizes (fr or px values). */
+  getRowSizes(): number[] {
+    return [...this.rowSizes];
+  }
+
+  /** Set column sizes (used by gutter drag handler). */
+  setColumnSizes(sizes: number[]): void {
+    this.columnSizes = [...sizes];
+  }
+
+  /** Set row sizes (used by gutter drag handler). */
+  setRowSizes(sizes: number[]): void {
+    this.rowSizes = [...sizes];
+  }
+
+  /**
+   * Apply current column/row sizes to the container's CSS grid properties.
+   *
+   * When sizes are set (from gutter drag), uses px values; otherwise falls
+   * back to 1fr per panel column with 4px gutters.
+   */
+  applyGridSizes(): void {
+    const config = this.currentConfig;
+    if (config.columns === 0) {
+      return;
+    }
+
+    // Build column template: interleave panel sizes with gutter sizes
+    const colParts: string[] = [];
+    for (let c = 0; c < config.columns; c++) {
+      if (c > 0) {
+        colParts.push(`${GUTTER_SIZE_PX}px`);
+      }
+      const size = this.columnSizes[c];
+      // 0 means "not yet measured in px" — use 1fr for equal distribution
+      colParts.push(size ? `${size}px` : "1fr");
+    }
+    this.container.style.gridTemplateColumns = colParts.join(" ");
+
+    // Build row template
+    const rowParts: string[] = [];
+    for (let r = 0; r < config.rows; r++) {
+      if (r > 0) {
+        rowParts.push(`${GUTTER_SIZE_PX}px`);
+      }
+      const size = this.rowSizes[r];
+      // 0 means "not yet measured in px" — use 1fr for equal distribution
+      rowParts.push(size ? `${size}px` : "1fr");
+    }
+    this.container.style.gridTemplateRows = rowParts.join(" ");
+  }
+
+  // -------------------------------------------------------------------------
+  // Private methods
+  // -------------------------------------------------------------------------
+
+  /**
+   * Clear and rebuild the entire grid layout.
+   *
+   * Strategy:
+   *   - Compute grid config from panel count.
+   *   - Set grid-template-columns/rows on the container (panel cols
+   *     interleaved with gutter cols).
+   *   - Place each panel using explicit grid-column / grid-row.
+   *   - Insert gutter divs between adjacent panels and rows.
+   */
+  private rebuildGrid(): void {
+    const panelCount = this.panelOrder.length;
+    const config = computeGridConfig(panelCount);
+    this.currentConfig = config;
+
+    console.warn("[layout] rebuildGrid: panels=", panelCount, "config=", config);
+
+    // Clear the container
+    while (this.container.firstChild) {
+      this.container.removeChild(this.container.firstChild);
+    }
+
+    if (panelCount === 0) {
+      this.container.style.display = "";
+      this.container.style.gridTemplateColumns = "";
+      this.container.style.gridTemplateRows = "";
+      this.columnSizes = [];
+      this.rowSizes = [];
+      return;
+    }
+
+    // Set container to CSS Grid
+    this.container.style.display = "grid";
+    this.container.style.minWidth = `${MIN_PANEL_WIDTH}px`;
+    this.container.style.minHeight = `${MIN_PANEL_HEIGHT}px`;
+
+    // Total CSS columns: panel columns interleaved with gutter columns
+    // e.g. 3 panel cols -> 1fr 4px 1fr 4px 1fr = 5 CSS columns
+    const totalCSSCols = config.columns > 0 ? config.columns * 2 - 1 : 0;
+
+    // Total CSS rows: panel rows interleaved with gutter rows
+    // e.g. 2 panel rows -> 1fr 4px 1fr = 3 CSS rows
+    const totalCSSRows = config.rows > 0 ? config.rows * 2 - 1 : 0;
+
+    // Build grid-template-columns
+    const colParts: string[] = [];
+    for (let c = 0; c < config.columns; c++) {
+      if (c > 0) {
+        colParts.push(`${GUTTER_SIZE_PX}px`);
+      }
+      colParts.push("1fr");
+    }
+    this.container.style.gridTemplateColumns = colParts.join(" ");
+
+    // Build grid-template-rows
+    const rowParts: string[] = [];
+    for (let r = 0; r < config.rows; r++) {
+      if (r > 0) {
+        rowParts.push(`${GUTTER_SIZE_PX}px`);
+      }
+      rowParts.push("1fr");
+    }
+    this.container.style.gridTemplateRows = rowParts.join(" ");
+
+    // Initialize size tracking arrays (1fr = 0, meaning "not yet measured in px")
+    this.columnSizes = new Array<number>(config.columns).fill(0);
+    this.rowSizes = new Array<number>(config.rows).fill(0);
+
+    // Place top row panels
+    // Panel at logical column c occupies CSS grid column (c * 2 + 1) (1-based)
+    // Top row is CSS grid row 1
+    for (let c = 0; c < config.topRowCount; c++) {
+      const sessionId = this.panelOrder[c];
+      const panel = this.panelMap.get(sessionId);
+      if (!panel) {
+        continue;
+      }
+      const cssCol = c * 2 + 1; // 1-based
+      panel.element.style.gridColumn = `${cssCol}`;
+      panel.element.style.gridRow = "1";
+      this.container.appendChild(panel.element);
+    }
+
+    // Insert column gutters between top-row panels
+    for (let c = 0; c < config.topRowCount - 1; c++) {
+      const gutter = document.createElement("div");
+      gutter.classList.add("gutter-col");
+      gutter.dataset.colIndex = String(c);
+      const cssCol = c * 2 + 2; // gutter sits between panel cols
+      gutter.style.gridColumn = `${cssCol}`;
+      // Gutter spans all rows (including row gutter)
+      gutter.style.gridRow = `1 / ${totalCSSRows + 1}`;
+      this.container.appendChild(gutter);
+    }
+
+    // For 2-row layouts: insert row gutter and bottom row panels
+    if (config.rows === 2) {
+      // Row gutter spanning all CSS columns, at CSS row 2
+      const rowGutter = document.createElement("div");
+      rowGutter.classList.add("gutter-row");
+      rowGutter.dataset.rowIndex = "0";
+      rowGutter.style.gridColumn = `1 / ${totalCSSCols + 1}`;
+      rowGutter.style.gridRow = "2";
+      this.container.appendChild(rowGutter);
+
+      // Place bottom row panels with proportional column spanning
+      // Bottom row panels share the full totalCSSCols width evenly
+      const bottomRowCSSRow = 3; // 1-based: row1=1, gutter=2, row2=3
+      for (let b = 0; b < config.bottomRowCount; b++) {
+        const sessionId = this.panelOrder[config.topRowCount + b];
+        const panel = this.panelMap.get(sessionId);
+        if (!panel) {
+          continue;
+        }
+
+        // Proportional placement across totalCSSCols
+        const startCol = Math.round(b * totalCSSCols / config.bottomRowCount) + 1; // 1-based
+        const endCol = Math.round((b + 1) * totalCSSCols / config.bottomRowCount) + 1;
+        panel.element.style.gridColumn = `${startCol} / ${endCol}`;
+        panel.element.style.gridRow = `${bottomRowCSSRow}`;
+        this.container.appendChild(panel.element);
+      }
+    }
+  }
+}
+
+export { MAX_PANELS, MIN_PANEL_WIDTH, MIN_PANEL_HEIGHT, GUTTER_SIZE_PX };

--- a/app/src/layout.ts
+++ b/app/src/layout.ts
@@ -4,7 +4,7 @@
  * PanelGrid manages an auto-tiled grid of terminal panels. Given N panels
  * (1-8), it computes a 1- or 2-row grid layout and places panels using
  * explicit CSS Grid column/row assignments. Gutter elements are inserted
- * between adjacent panels to support future drag-resize (T6).
+ * between adjacent panels for drag-resize via pointer events.
  *
  * Grid structure example (5 panels = 3 top + 2 bottom):
  *   grid-template-columns: 1fr 4px 1fr 4px 1fr
@@ -69,6 +69,9 @@ export class PanelGrid {
 
   /** Row sizes — initially empty; populated by rebuildGrid. */
   private rowSizes: number[] = [];
+
+  /** Optional callback invoked after gutter drag resize or grid rebuild. */
+  private onPanelResizeCallback: (() => void) | null = null;
 
   constructor(containerElement: HTMLElement) {
     this.container = containerElement;
@@ -265,6 +268,11 @@ export class PanelGrid {
     }
   }
 
+  /** Register a callback invoked after gutter drag resizes panels. */
+  onPanelResize(callback: () => void): void {
+    this.onPanelResizeCallback = callback;
+  }
+
   /** Return the current grid configuration. */
   getGridConfig(): GridConfig {
     return { ...this.currentConfig };
@@ -454,6 +462,229 @@ export class PanelGrid {
         this.container.appendChild(panel.element);
       }
     }
+
+    this.attachGutterListeners();
+
+    if (this.onPanelResizeCallback) {
+      this.onPanelResizeCallback();
+    }
+  }
+  /**
+   * Build a CSS grid-template-columns string from panel column widths.
+   * Interleaves gutter widths (GUTTER_SIZE_PX) between panel columns.
+   */
+  private buildColumnTemplate(panelWidths: number[]): string {
+    const parts: string[] = [];
+    for (let i = 0; i < panelWidths.length; i++) {
+      if (i > 0) {
+        parts.push(`${GUTTER_SIZE_PX}px`);
+      }
+      parts.push(`${panelWidths[i]}px`);
+    }
+    return parts.join(" ");
+  }
+
+  /**
+   * Build a CSS grid-template-rows string from panel row heights.
+   * Interleaves gutter heights (GUTTER_SIZE_PX) between panel rows.
+   */
+  private buildRowTemplate(panelHeights: number[]): string {
+    const parts: string[] = [];
+    for (let i = 0; i < panelHeights.length; i++) {
+      if (i > 0) {
+        parts.push(`${GUTTER_SIZE_PX}px`);
+      }
+      parts.push(`${panelHeights[i]}px`);
+    }
+    return parts.join(" ");
+  }
+
+  /**
+   * Extract panel-only sizes from a resolved grid template string.
+   *
+   * The template alternates: panelSize gutterSize panelSize gutterSize ...
+   * So panel sizes are at even indices (0, 2, 4, ...).
+   */
+  private extractPanelSizes(templateString: string): number[] {
+    const allSizes = templateString.split(" ").map(v => parseFloat(v));
+    const panelSizes: number[] = [];
+    for (let i = 0; i < allSizes.length; i += 2) {
+      panelSizes.push(allSizes[i]);
+    }
+    return panelSizes;
+  }
+
+  /**
+   * Attach pointer-event-based drag listeners to all gutter elements.
+   * Called at the end of rebuildGrid so listeners are fresh after DOM rebuild.
+   */
+  private attachGutterListeners(): void {
+    const colGutters = this.container.querySelectorAll<HTMLElement>(".gutter-col");
+    const rowGutters = this.container.querySelectorAll<HTMLElement>(".gutter-row");
+
+    for (const gutter of colGutters) {
+      gutter.addEventListener("pointerdown", (e: PointerEvent) => {
+        this.handleColumnGutterDragStart(gutter, e);
+      });
+    }
+
+    for (const gutter of rowGutters) {
+      gutter.addEventListener("pointerdown", (e: PointerEvent) => {
+        this.handleRowGutterDragStart(gutter, e);
+      });
+    }
+  }
+
+  /**
+   * Handle pointerdown on a column gutter — begin horizontal drag resize.
+   *
+   * The gutter at data-col-index N sits between panel column N and N+1.
+   * Dragging adjusts both adjacent columns while respecting MIN_PANEL_WIDTH.
+   */
+  private handleColumnGutterDragStart(gutter: HTMLElement, startEvent: PointerEvent): void {
+    console.warn("[layout] column gutter drag start, col-index:", gutter.dataset.colIndex);
+
+    const colIndex = parseInt(gutter.dataset.colIndex ?? "0", 10);
+    gutter.setPointerCapture(startEvent.pointerId);
+    startEvent.preventDefault();
+
+    // Read resolved column widths from computed style
+    const computed = getComputedStyle(this.container);
+    const initialPanelWidths = this.extractPanelSizes(computed.gridTemplateColumns);
+    const startX = startEvent.clientX;
+
+    // Visual feedback
+    gutter.classList.add("dragging");
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+
+    const leftIdx = colIndex;
+    const rightIdx = colIndex + 1;
+    const initialLeft = initialPanelWidths[leftIdx];
+    const initialRight = initialPanelWidths[rightIdx];
+
+    const onPointerMove = (e: PointerEvent): void => {
+      e.preventDefault();
+      const deltaX = e.clientX - startX;
+
+      // Compute candidate sizes
+      let newLeft = initialLeft + deltaX;
+      let newRight = initialRight - deltaX;
+
+      // Clamp to minimum width
+      if (newLeft < MIN_PANEL_WIDTH) {
+        newLeft = MIN_PANEL_WIDTH;
+        newRight = initialLeft + initialRight - MIN_PANEL_WIDTH;
+      }
+      if (newRight < MIN_PANEL_WIDTH) {
+        newRight = MIN_PANEL_WIDTH;
+        newLeft = initialLeft + initialRight - MIN_PANEL_WIDTH;
+      }
+
+      // Update the sizes array
+      const updatedWidths = [...initialPanelWidths];
+      updatedWidths[leftIdx] = newLeft;
+      updatedWidths[rightIdx] = newRight;
+
+      // Apply to DOM
+      this.container.style.gridTemplateColumns = this.buildColumnTemplate(updatedWidths);
+      this.setColumnSizes(updatedWidths);
+    };
+
+    const onPointerUp = (e: PointerEvent): void => {
+      console.warn("[layout] column gutter drag end, col-index:", gutter.dataset.colIndex);
+
+      gutter.releasePointerCapture(e.pointerId);
+      gutter.classList.remove("dragging");
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+
+      document.removeEventListener("pointermove", onPointerMove);
+      document.removeEventListener("pointerup", onPointerUp);
+
+      if (this.onPanelResizeCallback) {
+        this.onPanelResizeCallback();
+      }
+    };
+
+    document.addEventListener("pointermove", onPointerMove);
+    document.addEventListener("pointerup", onPointerUp);
+  }
+
+  /**
+   * Handle pointerdown on a row gutter — begin vertical drag resize.
+   *
+   * The gutter at data-row-index N sits between panel row N and N+1.
+   * Dragging adjusts both adjacent rows while respecting MIN_PANEL_HEIGHT.
+   */
+  private handleRowGutterDragStart(gutter: HTMLElement, startEvent: PointerEvent): void {
+    console.warn("[layout] row gutter drag start, row-index:", gutter.dataset.rowIndex);
+
+    const rowIndex = parseInt(gutter.dataset.rowIndex ?? "0", 10);
+    gutter.setPointerCapture(startEvent.pointerId);
+    startEvent.preventDefault();
+
+    // Read resolved row heights from computed style
+    const computed = getComputedStyle(this.container);
+    const initialPanelHeights = this.extractPanelSizes(computed.gridTemplateRows);
+    const startY = startEvent.clientY;
+
+    // Visual feedback
+    gutter.classList.add("dragging");
+    document.body.style.cursor = "row-resize";
+    document.body.style.userSelect = "none";
+
+    const topIdx = rowIndex;
+    const bottomIdx = rowIndex + 1;
+    const initialTop = initialPanelHeights[topIdx];
+    const initialBottom = initialPanelHeights[bottomIdx];
+
+    const onPointerMove = (e: PointerEvent): void => {
+      e.preventDefault();
+      const deltaY = e.clientY - startY;
+
+      // Compute candidate sizes
+      let newTop = initialTop + deltaY;
+      let newBottom = initialBottom - deltaY;
+
+      // Clamp to minimum height
+      if (newTop < MIN_PANEL_HEIGHT) {
+        newTop = MIN_PANEL_HEIGHT;
+        newBottom = initialTop + initialBottom - MIN_PANEL_HEIGHT;
+      }
+      if (newBottom < MIN_PANEL_HEIGHT) {
+        newBottom = MIN_PANEL_HEIGHT;
+        newTop = initialTop + initialBottom - MIN_PANEL_HEIGHT;
+      }
+
+      // Update the sizes array
+      const updatedHeights = [...initialPanelHeights];
+      updatedHeights[topIdx] = newTop;
+      updatedHeights[bottomIdx] = newBottom;
+
+      // Apply to DOM
+      this.container.style.gridTemplateRows = this.buildRowTemplate(updatedHeights);
+      this.setRowSizes(updatedHeights);
+    };
+
+    const onPointerUp = (e: PointerEvent): void => {
+      console.warn("[layout] row gutter drag end, row-index:", gutter.dataset.rowIndex);
+
+      gutter.releasePointerCapture(e.pointerId);
+      gutter.classList.remove("dragging");
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+
+      document.removeEventListener("pointermove", onPointerMove);
+      document.removeEventListener("pointerup", onPointerUp);
+
+      if (this.onPanelResizeCallback) {
+        this.onPanelResizeCallback();
+      }
+    };
+
+    document.addEventListener("pointermove", onPointerMove);
+    document.addEventListener("pointerup", onPointerUp);
   }
 }
 

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1,6 +1,14 @@
 :root {
   --bg-color: #1e1e1e;
   --text-color: #d4d4d4;
+  --panel-border-color: #333;
+  --panel-focus-border-color: #007acc;
+  --header-height: 24px;
+  --header-bg: #252526;
+  --header-text: #cccccc;
+  --gutter-size: 4px;
+  --gutter-color: #333;
+  --gutter-hover-color: #007acc;
 }
 
 * {
@@ -18,8 +26,209 @@ html, body {
   font-family: 'Cascadia Mono NF', 'Cascadia Code', 'Consolas', monospace;
 }
 
-#terminal-container {
+/* --- Grid Container --- */
+
+#grid-container {
+  display: grid;
   width: 100vw;
   height: 100vh;
-  padding: 0;
+  gap: 0;
+  background-color: var(--bg-color);
+  overflow: hidden;
+}
+
+/* --- Panel --- */
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--panel-border-color);
+  min-width: 120px;
+  min-height: 80px;
+  position: relative;
+}
+
+.panel.focused {
+  border-color: var(--panel-focus-border-color);
+}
+
+/* --- Panel Header --- */
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: var(--header-height);
+  min-height: var(--header-height);
+  max-height: var(--header-height);
+  background-color: var(--header-bg);
+  color: var(--header-text);
+  padding: 0 8px;
+  font-size: 12px;
+  user-select: none;
+  cursor: default;
+}
+
+.panel-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.panel-close-btn {
+  background: none;
+  border: none;
+  color: var(--header-text);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 4px;
+  opacity: 0.7;
+}
+
+.panel-close-btn:hover {
+  opacity: 1;
+  color: #e06c75;
+}
+
+/* --- Panel Content (terminal area) --- */
+
+.panel-content {
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+}
+
+/* --- Gutters --- */
+
+.gutter-col {
+  width: var(--gutter-size);
+  cursor: col-resize;
+  background-color: var(--gutter-color);
+}
+
+.gutter-col:hover {
+  background-color: var(--gutter-hover-color);
+}
+
+.gutter-row {
+  height: var(--gutter-size);
+  cursor: row-resize;
+  background-color: var(--gutter-color);
+}
+
+.gutter-row:hover {
+  background-color: var(--gutter-hover-color);
+}
+
+.gutter-col.dragging,
+.gutter-row.dragging {
+  background-color: var(--gutter-hover-color);
+}
+
+/* --- Add Panel Button --- */
+
+#add-panel-btn {
+  position: fixed;
+  bottom: 8px;
+  right: 8px;
+  width: 32px;
+  height: 32px;
+  background: var(--header-bg);
+  border: 1px solid var(--panel-border-color);
+  color: var(--header-text);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 4px;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#add-panel-btn:hover {
+  border-color: var(--panel-focus-border-color);
+  color: #fff;
+}
+
+/* --- Close Dialog --- */
+
+#close-dialog {
+  background: #2d2d2d;
+  color: var(--text-color);
+  border: 1px solid #555;
+  border-radius: 6px;
+  padding: 16px;
+  min-width: 320px;
+  max-width: 400px;
+  font-family: inherit;
+}
+
+#close-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.dialog-title {
+  font-size: 14px;
+  font-weight: bold;
+  margin-bottom: 12px;
+}
+
+.dialog-options {
+  margin-bottom: 12px;
+}
+
+.dialog-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  cursor: pointer;
+}
+
+.dialog-option label {
+  cursor: pointer;
+}
+
+.dialog-remember {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0;
+  border-top: 1px solid #444;
+  margin-top: 4px;
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.dialog-btn {
+  padding: 4px 16px;
+  border: 1px solid #555;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 13px;
+  background: #3c3c3c;
+  color: var(--text-color);
+}
+
+.dialog-btn:hover {
+  background: #4c4c4c;
+}
+
+.dialog-btn-primary {
+  background: #007acc;
+  border-color: #007acc;
+  color: #fff;
+}
+
+.dialog-btn-primary:hover {
+  background: #0098ff;
 }

--- a/app/src/terminal.ts
+++ b/app/src/terminal.ts
@@ -31,6 +31,8 @@ export class TerminalWrapper {
   private ws: WebSocket | null = null;
   private container: HTMLElement | null = null;
   private resizeHandler: (() => void) | null = null;
+  private onFocusCallback: ((sessionId: string) => void) | null = null;
+  private onDisposeCallback: ((sessionId: string) => void) | null = null;
 
   constructor(sessionId: string, daemonPort: number) {
     this.sessionId = sessionId;
@@ -51,10 +53,42 @@ export class TerminalWrapper {
   // Public API
   // ---------------------------------------------------------------------------
 
+  /** Register a callback invoked when the terminal receives focus (click). */
+  onFocus(callback: (sessionId: string) => void): void {
+    this.onFocusCallback = callback;
+  }
+
+  /** Register a callback invoked when the terminal is disposed. */
+  onDispose(callback: (sessionId: string) => void): void {
+    this.onDisposeCallback = callback;
+  }
+
+  /** Trigger a re-fit of the terminal to its container dimensions. */
+  fit(): void {
+    this.fitAddon.fit();
+  }
+
+  /** Programmatically focus the xterm.js terminal input. */
+  focusTerminal(): void {
+    this.terminal.focus();
+  }
+
+  /** Return current terminal dimensions (cols, rows). */
+  getDimensions(): { cols: number; rows: number } {
+    return { cols: this.terminal.cols, rows: this.terminal.rows };
+  }
+
   /** Mount the terminal into a DOM element and connect its WebSocket. */
   mount(container: HTMLElement): void {
     this.container = container;
     this.terminal.open(container);
+
+    // Click-to-focus: notify layout when this terminal is clicked.
+    container.addEventListener("mousedown", () => {
+      if (this.onFocusCallback) {
+        this.onFocusCallback(this.sessionId);
+      }
+    });
 
     this.loadWebGLAddon();
 
@@ -92,6 +126,10 @@ export class TerminalWrapper {
     }
     this.terminal.dispose();
     this.container = null;
+
+    if (this.onDisposeCallback) {
+      this.onDisposeCallback(this.sessionId);
+    }
   }
 
   /** Return the session ID this wrapper is bound to. */

--- a/app/src/terminal.ts
+++ b/app/src/terminal.ts
@@ -30,7 +30,7 @@ export class TerminalWrapper {
   private readonly fitAddon: FitAddon;
   private ws: WebSocket | null = null;
   private container: HTMLElement | null = null;
-  private resizeHandler: (() => void) | null = null;
+  private resizeObserver: ResizeObserver | null = null;
   private onFocusCallback: ((sessionId: string) => void) | null = null;
   private onDisposeCallback: ((sessionId: string) => void) | null = null;
 
@@ -100,11 +100,13 @@ export class TerminalWrapper {
       this.send({ type: "input", data });
     });
 
-    // Recalculate dimensions when the browser window resizes.
-    this.resizeHandler = () => {
+    // Observe container size changes for automatic re-fit (AC-12).
+    // ResizeObserver fires after layout settles, covering window resize,
+    // CSS Grid reflow (panel add/remove), and gutter drag resize.
+    this.resizeObserver = new ResizeObserver(() => {
       this.fitAddon.fit();
-    };
-    window.addEventListener("resize", this.resizeHandler);
+    });
+    this.resizeObserver.observe(container);
 
     // After fit recalculates, forward the new size to the daemon.
     this.terminal.onResize(({ cols, rows }) => {
@@ -116,9 +118,9 @@ export class TerminalWrapper {
 
   /** Tear down the terminal, close the WebSocket, and remove event listeners. */
   dispose(): void {
-    if (this.resizeHandler) {
-      window.removeEventListener("resize", this.resizeHandler);
-      this.resizeHandler = null;
+    if (this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = null;
     }
     if (this.ws) {
       this.ws.close();

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -94,5 +94,60 @@ declare global {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Panel & Layout types
+// ---------------------------------------------------------------------------
+
+/** User preference for what happens when closing a panel. */
+export type ClosePreference = "detach" | "kill";
+
+/** A single panel in the CSS Grid layout. */
+export interface PanelInfo {
+  /** The daemon session ID. */
+  sessionId: string;
+  /** Display title shown in the header bar. */
+  title: string;
+  /** Which workspace this panel belongs to. */
+  workspaceId: string;
+  /** The panel's root DOM element. */
+  element: HTMLElement;
+  /** The header bar element. */
+  headerElement: HTMLElement;
+  /** The terminal content area element. */
+  contentElement: HTMLElement;
+}
+
+/** Computed grid layout dimensions. */
+export interface GridConfig {
+  /** Number of columns. */
+  columns: number;
+  /** Number of rows (1 or 2). */
+  rows: number;
+  /** Number of panels in the top row. */
+  topRowCount: number;
+  /** Number of panels in the bottom row. */
+  bottomRowCount: number;
+}
+
+/** Runtime state for a single workspace. */
+export interface WorkspaceState {
+  /** Maps session ID to PanelInfo. */
+  panels: Map<string, PanelInfo>;
+  /** Currently focused panel's session ID, or null if none. */
+  focusedPanelId: string | null;
+  /** Current column sizes in pixels (for drag resize). */
+  columnSizes: number[];
+  /** Current row sizes in pixels (for drag resize). */
+  rowSizes: number[];
+}
+
+/** Return value from the close-panel confirmation dialog. */
+export interface CloseDialogResult {
+  /** Which action was chosen. */
+  action: ClosePreference;
+  /** Whether to save the preference for future closes. */
+  remember: boolean;
+}
+
 // Ensure this file is treated as a module (required when using `declare global`).
 export {};


### PR DESCRIPTION
## Summary

- Implement auto-tiled CSS Grid layout engine (`layout.ts`) that dynamically arranges 1-8 terminal panels in a 1-2 row grid with draggable gutters for resize
- Refactor `app.ts` to workspace-scoped session registry (`Map<workspaceId, Map<sessionId, TerminalWrapper>>`) with multi-panel lifecycle management
- Add keyboard shortcuts (`Ctrl+Shift+N/W/Arrow`), close confirmation dialog with localStorage preference persistence, and `Shift+click` override
- Replace window resize listener with `ResizeObserver` for reliable FitAddon refit on panel changes

## Changes

### New files
- `app/src/layout.ts` — PanelGrid class: auto-tile algorithm, panel CRUD, gutter drag resize, focus navigation

### Modified files
- `app/src/types.ts` — Added ClosePreference, PanelInfo, GridConfig, WorkspaceState, CloseDialogResult types
- `app/src/styles.css` — CSS Grid container, panel/header/gutter/dialog styles, focus highlight
- `app/src/index.html` — Grid container, "+" button, close confirmation `<dialog>`
- `app/src/app.ts` — Workspace-scoped registry, multi-session init, keyboard shortcuts, close flow
- `app/src/terminal.ts` — Click-to-focus callback, ResizeObserver, fit()/focusTerminal()/getDimensions() methods
- `CLAUDE.md` — Document keyboard shortcuts, multi-panel architecture, 8-panel limit

## Acceptance Criteria

All 15 ACs verified:
- [x] AC-1: Auto-tiled CSS Grid layout (columns=ceil(N/2), rows=1-2)
- [x] AC-2: Panel header (24px) with title + close button
- [x] AC-3: Click-to-focus with blue border (#007acc)
- [x] AC-4: Draggable gutters (4-6px) with min size 120x80px
- [x] AC-5: Ctrl+Shift+N creates new panel (max 8)
- [x] AC-6: Ctrl+Shift+W closes focused panel
- [x] AC-7: Ctrl+Shift+Arrow moves focus
- [x] AC-8: Close dialog with detach/kill options
- [x] AC-9: localStorage preference persistence
- [x] AC-10: Shift+click forces dialog override
- [x] AC-11: Workspace-scoped registry (default workspace)
- [x] AC-12: FitAddon refit + resize WebSocket notification
- [x] AC-13: "+" button for new panel
- [x] AC-14: CLAUDE.md documentation updated
- [x] AC-15: Strict TS, no any, const-preferred, warn/error only, no Electron API in src/

## Test plan

- [x] Start daemon + Electron app, verify initial single panel loads
- [x] Click "+" button to add panels (up to 8), verify auto-tile layout
- [x] Ctrl+Shift+N creates new panel, verify grid reflows
- [x] Drag gutters between panels, verify resize respects min sizes
- [x] Click panels to verify focus switching (blue border)
- [x] Ctrl+Shift+Arrow navigates between panels
- [x] Click [x] on panel, verify close dialog appears
- [x] Select "detach" + "remember", verify subsequent closes skip dialog
- [x] Shift+click [x] to force dialog override
- [x] Ctrl+Shift+W closes focused panel
- [x] Verify terminals refit correctly after add/remove/resize
- [x] Close all panels then re-add, verify grid handles empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
