### PR TITLE
feat: layout persistence with daemon API and restore reconciliation

### DIFF
--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -441,10 +441,9 @@ async function init(): Promise<void> {
     refitAllTerminals();
   });
 
-  // Register layout auto-save callback (fires on panel add/remove and gutter drag end)
-  panelGrid.onLayoutChange(() => {
-    saveLayout();
-  });
+  // NOTE: onLayoutChange callback is registered AFTER reconciliation completes
+  // to prevent intermediate saves from overwriting the daemon's saved custom
+  // grid template with auto-tiled values during mount.
 
   // Wire up the "+" button
   const addBtn = document.getElementById("add-panel-btn");
@@ -590,6 +589,18 @@ async function init(): Promise<void> {
 
   // AC-10: Refit all terminals after reconciliation
   refitAllTerminals();
+
+  // Register layout auto-save callback AFTER reconciliation is complete.
+  // During reconciliation, each addPanel() triggers rebuildGrid() which would
+  // fire this callback with auto-tiled grid template values, overwriting the
+  // daemon's saved custom template. Deferring registration prevents this.
+  panelGrid.onLayoutChange(() => {
+    saveLayout();
+  });
+
+  // Persist the final post-reconciliation layout state (with correct grid
+  // template — either restored custom values or auto-tiled) in a single save.
+  saveLayout();
 
   console.warn("[app] init exit");
 }

--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -511,20 +511,85 @@ async function init(): Promise<void> {
     }
   });
 
-  // Fetch existing sessions and reconnect
+  // Fetch sessions and layout state for reconciliation
   const sessionList = await apiGet<SessionInfo[]>("/api/sessions");
   const runningSessions = sessionList.filter((s) => s.status === "running");
+  const layoutState = await apiGet<LayoutState>("/api/layout");
 
-  if (runningSessions.length > 0) {
-    console.warn("[app] reconnecting to", runningSessions.length, "running sessions");
+  const hasLayout = layoutState.panels.length > 0;
+  const runningIds = new Set(runningSessions.map((s) => s.id));
+
+  if (hasLayout) {
+    console.warn("[app] restore: layout found with", layoutState.panels.length, "panels");
+
+    // Build a title lookup from running sessions
+    const titleMap = new Map<string, string>();
+    for (const s of runningSessions) {
+      titleMap.set(s.id, s.title);
+    }
+
+    // (a) Mount panels from layout in position order (only if session still exists)
+    const sortedPanels = [...layoutState.panels].sort((a, b) => a.position - b.position);
+    const mountedIds = new Set<string>();
+
+    for (const panel of sortedPanels) {
+      if (runningIds.has(panel.session_id)) {
+        const title = titleMap.get(panel.session_id) ?? "Terminal";
+        mountSessionToGrid(panel.session_id, title);
+        mountedIds.add(panel.session_id);
+      } else {
+        // (c) Layout references a dead session — skip
+        console.warn("[app] restore: skipping dead session:", panel.session_id);
+      }
+    }
+
+    // (b) Append sessions that exist but are not in layout
+    for (const s of runningSessions) {
+      if (!mountedIds.has(s.id)) {
+        console.warn("[app] restore: appending unlisted session:", s.id);
+        mountSessionToGrid(s.id, s.title);
+        mountedIds.add(s.id);
+      }
+    }
+
+    // AC-8: If actual panel count differs from layout record count
+    // (due to skipped or appended sessions), use auto-tiled grid template.
+    // Only apply saved grid template when counts match exactly.
+    const layoutPanelCount = layoutState.panels.length;
+    const actualPanelCount = mountedIds.size;
+
+    if (actualPanelCount === layoutPanelCount && actualPanelCount > 0) {
+      // Panel count matches — apply saved grid template values
+      console.warn("[app] restore: applying saved grid template");
+      panelGrid.applyLayoutTemplate(
+        layoutState.grid_template_columns,
+        layoutState.grid_template_rows,
+      );
+    } else if (actualPanelCount !== layoutPanelCount) {
+      // Count mismatch — auto-tiled grid was already set by rebuildGrid
+      console.warn("[app] restore: panel count mismatch (layout:", layoutPanelCount,
+        "actual:", actualPanelCount, "), using auto-tiled grid");
+    }
+
+    // If no panels were mounted at all, create a fresh one
+    if (mountedIds.size === 0) {
+      console.warn("[app] restore: no sessions survived reconciliation, creating initial session");
+      await createAndMountPanel("Terminal 1");
+    }
+  } else if (runningSessions.length > 0) {
+    // AC-9: No saved layout — fall back to default behavior
+    console.warn("[app] no layout saved, reconnecting to", runningSessions.length, "running sessions");
     for (const session of runningSessions) {
       mountSessionToGrid(session.id, session.title);
     }
   } else {
-    // No running sessions — create a fresh one
+    // No sessions and no layout — create a fresh one
     console.warn("[app] no running sessions, creating initial session");
     await createAndMountPanel("Terminal 1");
   }
+
+  // AC-10: Refit all terminals after reconciliation
+  refitAllTerminals();
 
   console.warn("[app] init exit");
 }

--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -19,6 +19,7 @@ import type {
   CreateSessionResponse,
   ClosePreference,
   CloseDialogResult,
+  LayoutState,
 } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -96,6 +97,40 @@ async function apiDelete(path: string): Promise<void> {
   if (!resp.ok) {
     throw new Error(`DELETE ${path} failed: ${resp.status} ${resp.statusText}`);
   }
+}
+
+/** Typed PUT against the daemon REST API. */
+async function apiPut<TReq>(path: string, body: TReq): Promise<void> {
+  const port = getDaemonPort();
+  const resp = await fetch(`http://localhost:${port}${path}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!resp.ok) {
+    throw new Error(`PUT ${path} failed: ${resp.status} ${resp.statusText}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Layout persistence
+// ---------------------------------------------------------------------------
+
+/**
+ * Save the current layout state to the daemon via PUT /api/layout.
+ * Called automatically on panel add/remove and gutter drag end.
+ */
+function saveLayout(): void {
+  if (!panelGrid) {
+    return;
+  }
+
+  const state: LayoutState = panelGrid.serializeLayout();
+  console.warn("[app] saveLayout: saving", state.panels.length, "panels");
+
+  apiPut("/api/layout", state).catch((err: unknown) => {
+    console.error("[app] saveLayout: failed to save layout:", err);
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -404,6 +439,11 @@ async function init(): Promise<void> {
   // Register resize callback for FitAddon
   panelGrid.onPanelResize(() => {
     refitAllTerminals();
+  });
+
+  // Register layout auto-save callback (fires on panel add/remove and gutter drag end)
+  panelGrid.onLayoutChange(() => {
+    saveLayout();
   });
 
   // Wire up the "+" button

--- a/app/src/layout.ts
+++ b/app/src/layout.ts
@@ -13,7 +13,7 @@
  *   Bottom row panels span proportionally across all 5 CSS columns at row 3.
  */
 
-import type { PanelInfo, GridConfig } from "./types";
+import type { PanelInfo, GridConfig, LayoutState, PanelLayout } from "./types";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -72,6 +72,9 @@ export class PanelGrid {
 
   /** Optional callback invoked after gutter drag resize or grid rebuild. */
   private onPanelResizeCallback: (() => void) | null = null;
+
+  /** Optional callback invoked when layout should be saved (panel add/remove, gutter drag end). */
+  private onLayoutChangeCallback: (() => void) | null = null;
 
   constructor(containerElement: HTMLElement) {
     this.container = containerElement;
@@ -132,6 +135,10 @@ export class PanelGrid {
     this.panelMap.set(sessionId, panelInfo);
     this.rebuildGrid();
 
+    if (this.onLayoutChangeCallback) {
+      this.onLayoutChangeCallback();
+    }
+
     console.warn("[layout] addPanel exit:", sessionId);
     return panelInfo;
   }
@@ -163,6 +170,10 @@ export class PanelGrid {
     }
 
     this.rebuildGrid();
+
+    if (this.onLayoutChangeCallback) {
+      this.onLayoutChangeCallback();
+    }
 
     console.warn("[layout] removePanel exit:", sessionId);
   }
@@ -271,6 +282,31 @@ export class PanelGrid {
   /** Register a callback invoked after gutter drag resizes panels. */
   onPanelResize(callback: () => void): void {
     this.onPanelResizeCallback = callback;
+  }
+
+  /** Register a callback invoked when layout changes (panel add/remove, gutter drag end). */
+  onLayoutChange(callback: () => void): void {
+    this.onLayoutChangeCallback = callback;
+  }
+
+  /** Serialize the current layout state for persistence via PUT /api/layout. */
+  serializeLayout(): LayoutState {
+    const panels: PanelLayout[] = this.panelOrder.map((sessionId, index) => ({
+      session_id: sessionId,
+      position: index,
+    }));
+
+    return {
+      panels,
+      grid_template_columns: this.container.style.gridTemplateColumns,
+      grid_template_rows: this.container.style.gridTemplateRows,
+    };
+  }
+
+  /** Apply saved grid template values from a persisted layout state. */
+  applyLayoutTemplate(gridTemplateColumns: string, gridTemplateRows: string): void {
+    this.container.style.gridTemplateColumns = gridTemplateColumns;
+    this.container.style.gridTemplateRows = gridTemplateRows;
   }
 
   /** Return the current grid configuration. */
@@ -605,6 +641,10 @@ export class PanelGrid {
       if (this.onPanelResizeCallback) {
         this.onPanelResizeCallback();
       }
+
+      if (this.onLayoutChangeCallback) {
+        this.onLayoutChangeCallback();
+      }
     };
 
     document.addEventListener("pointermove", onPointerMove);
@@ -680,6 +720,10 @@ export class PanelGrid {
 
       if (this.onPanelResizeCallback) {
         this.onPanelResizeCallback();
+      }
+
+      if (this.onLayoutChangeCallback) {
+        this.onLayoutChangeCallback();
       }
     };
 

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -149,5 +149,27 @@ export interface CloseDialogResult {
   remember: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Layout persistence API types (daemon/server/api.go)
+// ---------------------------------------------------------------------------
+
+/** A single panel's position in the saved layout. */
+export interface PanelLayout {
+  /** The daemon session ID. */
+  session_id: string;
+  /** Zero-based position index in the grid. */
+  position: number;
+}
+
+/** Layout state saved to/loaded from the daemon via GET/PUT /api/layout. */
+export interface LayoutState {
+  /** Ordered list of panels with their positions. */
+  panels: PanelLayout[];
+  /** CSS grid-template-columns value (e.g. "1fr 6px 1fr"). */
+  grid_template_columns: string;
+  /** CSS grid-template-rows value (e.g. "1fr"). */
+  grid_template_rows: string;
+}
+
 // Ensure this file is treated as a module (required when using `declare global`).
 export {};

--- a/daemon/server/api.go
+++ b/daemon/server/api.go
@@ -11,6 +11,24 @@ import (
 )
 
 // ---------------------------------------------------------------------------
+// Layout state types
+// ---------------------------------------------------------------------------
+
+// panelLayout represents a single panel's position in the saved layout.
+type panelLayout struct {
+	SessionID string `json:"session_id"`
+	Position  int    `json:"position"`
+}
+
+// layoutState represents the complete layout configuration.
+// Stored in-memory on the Server struct — not persisted to disk.
+type layoutState struct {
+	Panels              []panelLayout `json:"panels"`
+	GridTemplateColumns string        `json:"grid_template_columns"`
+	GridTemplateRows    string        `json:"grid_template_rows"`
+}
+
+// ---------------------------------------------------------------------------
 // Health endpoint
 // ---------------------------------------------------------------------------
 
@@ -219,6 +237,60 @@ func (s *Server) handlePatchSession(w http.ResponseWriter, r *http.Request) {
 	)
 
 	writeJSON(w, http.StatusOK, sess.Info())
+}
+
+// ---------------------------------------------------------------------------
+// Layout endpoints
+// ---------------------------------------------------------------------------
+
+// handleGetLayout returns the current layout state.
+// Returns HTTP 200 with empty state if no layout has been saved.
+func (s *Server) handleGetLayout(w http.ResponseWriter, r *http.Request) {
+	slog.Info("server.handleGetLayout: retrieving layout")
+
+	s.layoutMu.Lock()
+	state := s.layout
+	s.layoutMu.Unlock()
+
+	// Ensure panels is never null in JSON output
+	if state.Panels == nil {
+		state.Panels = []panelLayout{}
+	}
+
+	slog.Info("server.handleGetLayout: layout retrieved",
+		slog.Int("panels", len(state.Panels)),
+	)
+
+	writeJSON(w, http.StatusOK, state)
+}
+
+// handlePutLayout saves a new layout state, replacing any previous state.
+func (s *Server) handlePutLayout(w http.ResponseWriter, r *http.Request) {
+	slog.Info("server.handlePutLayout: processing layout save")
+
+	var state layoutState
+	if err := json.NewDecoder(r.Body).Decode(&state); err != nil {
+		slog.Warn("server.handlePutLayout: invalid request body",
+			slog.String("error", err.Error()),
+		)
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Ensure panels is never nil
+	if state.Panels == nil {
+		state.Panels = []panelLayout{}
+	}
+
+	s.layoutMu.Lock()
+	s.layout = state
+	s.layoutMu.Unlock()
+
+	slog.Info("server.handlePutLayout: layout saved",
+		slog.Int("panels", len(state.Panels)),
+	)
+
+	writeJSON(w, http.StatusOK, state)
 }
 
 // ---------------------------------------------------------------------------

--- a/daemon/server/router.go
+++ b/daemon/server/router.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"regexp"
+	"sync"
 	"time"
 
 	"github.com/zac15987/zplex/daemon/session"
@@ -28,6 +29,8 @@ type Server struct {
 	mgr       *session.SessionManager
 	startTime time.Time
 	version   string
+	layoutMu  sync.Mutex
+	layout    layoutState
 }
 
 // NewServer creates a Server wired to the given session manager. The returned
@@ -53,6 +56,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/sessions/{id}", s.handleGetSession)
 	mux.HandleFunc("DELETE /api/sessions/{id}", s.handleDeleteSession)
 	mux.HandleFunc("PATCH /api/sessions/{id}", s.handlePatchSession)
+
+	mux.HandleFunc("GET /api/layout", s.handleGetLayout)
+	mux.HandleFunc("PUT /api/layout", s.handlePutLayout)
 
 	mux.HandleFunc("GET /ws/{session_id}", s.handleWebSocket)
 


### PR DESCRIPTION
## Summary

- Add `GET /api/layout` and `PUT /api/layout` daemon endpoints for in-memory layout state persistence (panels + grid template values)
- Add `LayoutState` / `PanelLayout` TypeScript types mirroring the daemon JSON contract
- Add `serializeLayout()` and `applyLayoutTemplate()` methods to `PanelGrid` for layout serialization/deserialization
- Wire up auto-save: `PUT /api/layout` fires on panel add/remove and gutter drag end (pointerup), not during drag or focus changes
- Implement restore reconciliation on init: fetch sessions + layout, mount panels in saved order, append unlisted sessions, skip dead sessions, apply saved grid template only when panel count matches

## Test plan

- [x] Start daemon, open Electron, create 2-3 panels
- [x] Close Electron, reopen -- verify panels restore in same order with same layout
- [x] Drag gutter to resize panels, close/reopen -- verify custom sizes are preserved
- [x] Kill a session via daemon API while Electron is closed, reopen -- verify dead session is skipped and remaining panels use auto-tiled layout
- [x] Restart daemon (kills all sessions), reopen Electron -- verify fresh session is created (no stale layout)
- [x] Verify focus switching does NOT trigger PUT /api/layout (check daemon logs)
- [x] Verify `GET /api/layout` with no saved layout returns `{ "panels": [], "grid_template_columns": "", "grid_template_rows": "" }`

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
