### PR TITLE
Workspace tab bar with dispose/recreate switching and layout API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Electron (main.ts)
 Frontend (TypeScript + xterm.js)
   → one xterm.js instance per panel
   → each connects via WebSocket to /ws/{session_id}
-  → layout managed by CSS Grid
+  → layout managed by CSS Grid + workspace tabs
 
 Go Daemon (single binary, port 17732)
   → REST API: session CRUD, health, layout state
@@ -66,13 +66,27 @@ The frontend uses an auto-tiled CSS Grid layout engine (`app/src/layout.ts`) tha
 - **Workspace-scoped registry**: Sessions are organized as `Map<workspaceId, Map<sessionId, TerminalWrapper>>` in `app.ts`. Current default workspace is `"default"`.
 - **Gutter drag resize**: Panels can be resized by dragging gutter bars between them. Minimum panel size: 120px wide, 80px tall.
 
+### Workspace Tabs
+
+The frontend supports multiple workspaces, each with its own set of terminal panels:
+
+- **WorkspaceManager** (`workspace.ts`): Manages workspace lifecycle — create, switch, close, rename. Renders the tab bar UI. Fires callbacks that `app.ts` handles for terminal dispose/recreate.
+- **Dispose/Recreate mechanism**: When switching workspaces, all xterm.js instances in the current workspace are disposed (freeing memory + WebGL contexts). The target workspace's panels are recreated from daemon layout data, with ring buffer replay providing near-instant recovery.
+- **Maximum 8 workspaces**. Attempts to add more are ignored with a console warning.
+- **Auto-naming**: New workspaces are named "Workspace N" (N auto-increments). Double-click tab to rename.
+- **Active workspace persistence**: Current workspace ID stored in `localStorage` key `zplex:activeWorkspace`. Restored on app restart.
+- **Close workspace**: Shows confirmation dialog if workspace has running sessions (shares `zplex:closePreference` with panel close). Last workspace cannot be closed.
+
 ### Keyboard Shortcuts
 
 | Shortcut | Action |
 |----------|--------|
 | `Ctrl+Shift+N` | Create new terminal panel |
+| `Ctrl+Shift+T` | Create new workspace tab |
 | `Ctrl+Shift+W` | Close focused panel (shows dialog or uses saved preference) |
 | `Ctrl+Shift+Arrow` | Move focus to adjacent panel (Up/Down/Left/Right) |
+| `Ctrl+Shift+PageUp` | Switch to previous workspace (wraps around) |
+| `Ctrl+Shift+PageDown` | Switch to next workspace (wraps around) |
 | `Shift+Click [×]` | Force close dialog (override saved preference) |
 
 ### Daemon REST API
@@ -82,7 +96,9 @@ The frontend uses an auto-tiled CSS Grid layout engine (`app/src/layout.ts`) tha
 | GET | `/api/health` | Health check + version |
 | GET/POST | `/api/sessions` | List / create sessions |
 | GET/DELETE/PATCH | `/api/sessions/{id}` | Get / kill / update session |
-| GET/PUT | `/api/layout` | Get / save panel layout |
+| GET/PUT | `/api/layout` | Get / save panel layout (per workspace) |
+| GET | `/api/workspaces` | List workspace IDs with layout data |
+| DELETE | `/api/workspaces/{id}` | Delete workspace layout data |
 | GET | `/api/events` | SSE stream for real-time updates |
 
 ### WebSocket Protocol (`/ws/{session_id}`)

--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -13,6 +13,7 @@
 
 import { TerminalWrapper } from "./terminal";
 import { PanelGrid } from "./layout";
+import { WorkspaceManager } from "./workspace";
 import type {
   SessionInfo,
   CreateSessionRequest,
@@ -20,6 +21,8 @@ import type {
   ClosePreference,
   CloseDialogResult,
   LayoutState,
+  WorkspaceInfo,
+  WorkspaceListResponse,
 } from "./types";
 
 // ---------------------------------------------------------------------------
@@ -54,6 +57,12 @@ function getWorkspaceRegistry(workspaceId: string): Map<string, TerminalWrapper>
 // ---------------------------------------------------------------------------
 
 let panelGrid: PanelGrid | null = null;
+let wsManager: WorkspaceManager | null = null;
+
+/** Return the active workspace ID, falling back to DEFAULT_WORKSPACE_ID. */
+function activeWorkspaceId(): string {
+  return wsManager?.getActiveId() ?? DEFAULT_WORKSPACE_ID;
+}
 
 // ---------------------------------------------------------------------------
 // Daemon communication helpers
@@ -121,14 +130,15 @@ async function apiPut<TReq>(path: string, body: TReq): Promise<void> {
  * Called automatically on panel add/remove and gutter drag end.
  */
 function saveLayout(): void {
-  if (!panelGrid) {
+  if (!panelGrid || !wsManager) {
     return;
   }
 
+  const workspaceId = wsManager.getActiveId();
   const state: LayoutState = panelGrid.serializeLayout();
-  console.warn("[app] saveLayout: saving", state.panels.length, "panels");
+  console.warn("[app] saveLayout: saving", state.panels.length, "panels for workspace:", workspaceId);
 
-  apiPut("/api/layout", state).catch((err: unknown) => {
+  apiPut(`/api/layout?workspace=${encodeURIComponent(workspaceId)}`, state).catch((err: unknown) => {
     console.error("[app] saveLayout: failed to save layout:", err);
   });
 }
@@ -179,7 +189,8 @@ function mountSessionToGrid(sessionId: string, title: string): void {
     return;
   }
 
-  const panelInfo = panelGrid.addPanel(sessionId, title, DEFAULT_WORKSPACE_ID);
+  const currentWorkspace = activeWorkspaceId();
+  const panelInfo = panelGrid.addPanel(sessionId, title, currentWorkspace);
   if (!panelInfo) {
     // Max panels reached
     return;
@@ -195,7 +206,7 @@ function mountSessionToGrid(sessionId: string, title: string): void {
   });
 
   // Register in workspace registry
-  const registry = getWorkspaceRegistry(DEFAULT_WORKSPACE_ID);
+  const registry = getWorkspaceRegistry(currentWorkspace);
   registry.set(sessionId, wrapper);
 
   // Mount xterm into the panel's content area
@@ -322,7 +333,8 @@ async function executeClose(sessionId: string, action: ClosePreference): Promise
   }
 
   // Dispose terminal wrapper
-  const registry = getWorkspaceRegistry(DEFAULT_WORKSPACE_ID);
+  const currentWorkspace = activeWorkspaceId();
+  const registry = getWorkspaceRegistry(currentWorkspace);
   const wrapper = registry.get(sessionId);
   if (wrapper) {
     wrapper.dispose();
@@ -407,11 +419,172 @@ function moveFocus(direction: "up" | "down" | "left" | "right"): void {
   if (!adjacentId) return;
 
   panelGrid.setFocus(adjacentId);
-  const registry = getWorkspaceRegistry(DEFAULT_WORKSPACE_ID);
+  const registry = getWorkspaceRegistry(activeWorkspaceId());
   const wrapper = registry.get(adjacentId);
   if (wrapper) {
     wrapper.focusTerminal();
   }
+}
+
+// ---------------------------------------------------------------------------
+// Workspace switching
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle workspace switch: dispose current panels, fetch target layout,
+ * recreate panels for the target workspace.
+ */
+async function handleWorkspaceSwitch(fromId: string, toId: string): Promise<void> {
+  console.warn("[app] handleWorkspaceSwitch entry:", fromId, "->", toId);
+
+  if (!panelGrid) return;
+
+  // 1. Dispose all xterm.js instances in the current workspace
+  const fromRegistry = getWorkspaceRegistry(fromId);
+  for (const [, wrapper] of fromRegistry) {
+    wrapper.dispose();
+  }
+  fromRegistry.clear();
+
+  // 2. Clear the grid (remove all panel DOM elements)
+  panelGrid.disposeAllPanels();
+
+  // 3. Fetch target workspace layout from daemon
+  const layoutState = await apiGet<LayoutState>(
+    `/api/layout?workspace=${encodeURIComponent(toId)}`,
+  );
+
+  // 4. Fetch running sessions for title lookup
+  const sessionList = await apiGet<SessionInfo[]>("/api/sessions");
+  const runningSessions = sessionList.filter((s) => s.status === "running");
+  const runningIds = new Set(runningSessions.map((s) => s.id));
+  const titleMap = new Map<string, string>();
+  for (const s of runningSessions) {
+    titleMap.set(s.id, s.title);
+  }
+
+  const hasLayout = layoutState.panels.length > 0;
+
+  if (hasLayout) {
+    // Mount panels from saved layout
+    const sortedPanels = [...layoutState.panels].sort((a, b) => a.position - b.position);
+    const mountedIds = new Set<string>();
+
+    for (const panel of sortedPanels) {
+      if (runningIds.has(panel.session_id)) {
+        const title = titleMap.get(panel.session_id) ?? "Terminal";
+        mountSessionToGrid(panel.session_id, title);
+        mountedIds.add(panel.session_id);
+      }
+    }
+
+    // Apply saved grid template if panel count matches
+    if (mountedIds.size === layoutState.panels.length && mountedIds.size > 0) {
+      panelGrid.applyLayoutTemplate(
+        layoutState.grid_template_columns,
+        layoutState.grid_template_rows,
+      );
+    }
+  }
+
+  // 5. Refit all terminals
+  refitAllTerminals();
+
+  console.warn("[app] handleWorkspaceSwitch exit:", toId);
+}
+
+/**
+ * Handle workspace close: check for running sessions, show dialog if needed,
+ * dispose terminals, and clean up daemon layout data.
+ */
+async function handleWorkspaceClose(workspaceId: string): Promise<void> {
+  console.warn("[app] handleWorkspaceClose entry:", workspaceId);
+
+  const registry = getWorkspaceRegistry(workspaceId);
+  const runningSessions: string[] = [];
+
+  // Check which sessions in this workspace are still running
+  try {
+    const sessionList = await apiGet<SessionInfo[]>("/api/sessions");
+    const runningIds = new Set(
+      sessionList.filter((s) => s.status === "running").map((s) => s.id),
+    );
+    for (const sessionId of registry.keys()) {
+      if (runningIds.has(sessionId)) {
+        runningSessions.push(sessionId);
+      }
+    }
+  } catch (err: unknown) {
+    console.error("[app] handleWorkspaceClose: failed to fetch sessions:", err);
+  }
+
+  // If there are running sessions, show close dialog
+  if (runningSessions.length > 0) {
+    const saved = localStorage.getItem(CLOSE_PREFERENCE_KEY) as ClosePreference | null;
+    const validSaved = (saved === "detach" || saved === "kill") ? saved : undefined;
+
+    let action: ClosePreference = "detach";
+
+    if (validSaved) {
+      action = validSaved;
+    } else {
+      // Update dialog text for workspace context
+      const dialogTitle = document.querySelector("#close-dialog .dialog-title");
+      const originalText = dialogTitle?.textContent ?? "Close Panel";
+      if (dialogTitle) {
+        dialogTitle.textContent = `此 workspace 有 ${runningSessions.length} 個執行中的 session`;
+      }
+
+      const result = await showCloseDialog(validSaved);
+
+      // Restore dialog text
+      if (dialogTitle) {
+        dialogTitle.textContent = originalText;
+      }
+
+      if (!result) {
+        // User cancelled — abort workspace close
+        throw new Error("workspace close cancelled by user");
+      }
+
+      if (result.remember) {
+        localStorage.setItem(CLOSE_PREFERENCE_KEY, result.action);
+      }
+      action = result.action;
+    }
+
+    // Kill sessions if requested
+    if (action === "kill") {
+      for (const sessionId of runningSessions) {
+        try {
+          await apiDelete(`/api/sessions/${sessionId}`);
+        } catch (err: unknown) {
+          console.error("[app] handleWorkspaceClose: failed to kill session:", sessionId, err);
+        }
+      }
+    }
+  }
+
+  // Dispose all xterm.js instances in this workspace
+  for (const [, wrapper] of registry) {
+    wrapper.dispose();
+  }
+  registry.clear();
+  workspaces.delete(workspaceId);
+
+  // If this was the active workspace, clear the grid
+  if (wsManager && workspaceId === wsManager.getActiveId()) {
+    panelGrid?.disposeAllPanels();
+  }
+
+  // Delete workspace layout from daemon
+  try {
+    await apiDelete(`/api/workspaces/${encodeURIComponent(workspaceId)}`);
+  } catch (err: unknown) {
+    console.error("[app] handleWorkspaceClose: failed to delete workspace layout:", err);
+  }
+
+  console.warn("[app] handleWorkspaceClose exit:", workspaceId);
 }
 
 // ---------------------------------------------------------------------------
@@ -445,6 +618,24 @@ async function init(): Promise<void> {
   // to prevent intermediate saves from overwriting the daemon's saved custom
   // grid template with auto-tiled values during mount.
 
+  // Initialize WorkspaceManager
+  wsManager = new WorkspaceManager();
+
+  // Register workspace callbacks
+  wsManager.onSwitch((fromId: string, toId: string) => {
+    handleWorkspaceSwitch(fromId, toId).catch((err: unknown) => {
+      console.error("[app] workspace switch failed:", err);
+    });
+  });
+
+  wsManager.onCreate((_workspace: WorkspaceInfo) => {
+    // New workspace starts empty — panel will be created after switch
+  });
+
+  wsManager.onClose(async (workspaceId: string) => {
+    await handleWorkspaceClose(workspaceId);
+  });
+
   // Wire up the "+" button
   const addBtn = document.getElementById("add-panel-btn");
   if (addBtn) {
@@ -455,7 +646,7 @@ async function init(): Promise<void> {
     });
   }
 
-  // Keyboard shortcuts (AC-5, AC-6, AC-7)
+  // Keyboard shortcuts (AC-5, AC-6, AC-7, workspace shortcuts)
   document.addEventListener("keydown", (e: KeyboardEvent) => {
     // All shortcuts require Ctrl+Shift
     if (!e.ctrlKey || !e.shiftKey) {
@@ -473,16 +664,45 @@ async function init(): Promise<void> {
         break;
       }
 
-      // Ctrl+Shift+W: Close focused panel (AC-6)
+      // Ctrl+Shift+W: Close focused panel (AC-6, AC-8)
       case "W":
       case "w": {
         e.preventDefault();
         const focusedId = panelGrid?.getFocusedPanelId();
         if (focusedId) {
+          // AC-8: Don't close the last panel in the last workspace
+          const panelCount = panelGrid?.getPanelCount() ?? 0;
+          const workspaceCount = wsManager?.getCount() ?? 1;
+          if (panelCount <= 1 && workspaceCount <= 1) {
+            console.warn("[app] cannot close last panel in last workspace");
+            break;
+          }
           closePanelFlow(focusedId, false).catch((err: unknown) => {
             console.error("[app] failed to close panel via shortcut:", err);
           });
         }
+        break;
+      }
+
+      // Ctrl+Shift+T: New workspace (AC-4)
+      case "T":
+      case "t": {
+        e.preventDefault();
+        wsManager?.createWorkspace();
+        break;
+      }
+
+      // Ctrl+Shift+PageUp: Previous workspace (AC-6)
+      case "PageUp": {
+        e.preventDefault();
+        wsManager?.switchPrevious();
+        break;
+      }
+
+      // Ctrl+Shift+PageDown: Next workspace (AC-6)
+      case "PageDown": {
+        e.preventDefault();
+        wsManager?.switchNext();
         break;
       }
 
@@ -510,10 +730,26 @@ async function init(): Promise<void> {
     }
   });
 
-  // Fetch sessions and layout state for reconciliation
+  // Fetch workspace list from daemon
+  let workspaceIds: string[] = [];
+  try {
+    workspaceIds = await apiGet<WorkspaceListResponse>("/api/workspaces");
+  } catch (err: unknown) {
+    console.warn("[app] failed to fetch workspace list, starting fresh:", err);
+  }
+
+  // Initialize WorkspaceManager (sets active workspace from localStorage or first)
+  wsManager.initFromList(workspaceIds);
+
+  const activeWorkspace = wsManager.getActiveId();
+  console.warn("[app] active workspace:", activeWorkspace);
+
+  // Fetch sessions and layout state for the active workspace
   const sessionList = await apiGet<SessionInfo[]>("/api/sessions");
   const runningSessions = sessionList.filter((s) => s.status === "running");
-  const layoutState = await apiGet<LayoutState>("/api/layout");
+  const layoutState = await apiGet<LayoutState>(
+    `/api/layout?workspace=${encodeURIComponent(activeWorkspace)}`,
+  );
 
   const hasLayout = layoutState.panels.length > 0;
   const runningIds = new Set(runningSessions.map((s) => s.id));

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -8,6 +8,12 @@
   <link rel="stylesheet" href="./styles.css">
 </head>
 <body>
+  <!-- Workspace tab bar: tabs are inserted dynamically by workspace.ts -->
+  <div id="tab-bar">
+    <div id="tab-bar-tabs"></div>
+    <button id="tab-bar-add" title="New workspace (Ctrl+Shift+T)">+</button>
+  </div>
+
   <!-- Grid container: panels and gutters are inserted dynamically by layout.ts -->
   <div id="grid-container"></div>
 

--- a/app/src/layout.ts
+++ b/app/src/layout.ts
@@ -178,6 +178,35 @@ export class PanelGrid {
     console.warn("[layout] removePanel exit:", sessionId);
   }
 
+  /**
+   * Remove all panels from the grid. Used during workspace switching to
+   * clear the grid before recreating panels for the target workspace.
+   * Does NOT fire onLayoutChange to avoid intermediate saves.
+   */
+  disposeAllPanels(): void {
+    console.warn("[layout] disposeAllPanels entry, panels:", this.panelOrder.length);
+
+    // Remove all children from container
+    while (this.container.firstChild) {
+      this.container.removeChild(this.container.firstChild);
+    }
+
+    // Clear internal state
+    this.panelMap.clear();
+    this.panelOrder.length = 0;
+    this.focusedPanelId = null;
+    this.columnSizes = [];
+    this.rowSizes = [];
+    this.currentConfig = { columns: 0, rows: 0, topRowCount: 0, bottomRowCount: 0 };
+
+    // Reset container grid styles
+    this.container.style.display = "";
+    this.container.style.gridTemplateColumns = "";
+    this.container.style.gridTemplateRows = "";
+
+    console.warn("[layout] disposeAllPanels exit");
+  }
+
   /** Set focus on a panel, removing focus from all others. */
   setFocus(sessionId: string): void {
     console.warn("[layout] setFocus:", sessionId);

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -26,12 +26,137 @@ html, body {
   font-family: 'Cascadia Mono NF', 'Cascadia Code', 'Consolas', monospace;
 }
 
+/* --- Tab Bar --- */
+
+#tab-bar {
+  display: flex;
+  align-items: center;
+  height: 32px;
+  min-height: 32px;
+  max-height: 32px;
+  background-color: #252526;
+  border-bottom: 1px solid var(--panel-border-color);
+  user-select: none;
+  overflow: hidden;
+}
+
+#tab-bar-tabs {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  overflow-x: auto;
+  overflow-y: hidden;
+  height: 100%;
+}
+
+/* Hide scrollbar but keep functionality */
+#tab-bar-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.workspace-tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 100%;
+  padding: 0 12px;
+  background-color: #2d2d2d;
+  color: #969696;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  border-right: 1px solid #1e1e1e;
+  position: relative;
+  flex-shrink: 0;
+}
+
+.workspace-tab:hover {
+  background-color: #353535;
+  color: #d4d4d4;
+}
+
+.workspace-tab.active {
+  background-color: #007acc;
+  color: #ffffff;
+}
+
+.workspace-tab.active:hover {
+  background-color: #0088e0;
+}
+
+.workspace-tab-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 150px;
+}
+
+/* Inline edit input for renaming workspace */
+.workspace-tab-input {
+  background: transparent;
+  border: 1px solid #007acc;
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
+  padding: 0 2px;
+  width: 120px;
+  outline: none;
+}
+
+.workspace-tab-close {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+  opacity: 0;
+  transition: opacity 0.1s;
+}
+
+.workspace-tab:hover .workspace-tab-close,
+.workspace-tab.active .workspace-tab-close {
+  opacity: 0.7;
+}
+
+.workspace-tab-close:hover {
+  opacity: 1;
+  color: #e06c75;
+}
+
+/* Hide close button when it's the last workspace */
+.workspace-tab-close.hidden {
+  display: none;
+}
+
+#tab-bar-add {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  margin: 0 4px;
+  background: none;
+  border: none;
+  color: #969696;
+  font-size: 18px;
+  cursor: pointer;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+#tab-bar-add:hover {
+  background-color: #353535;
+  color: #d4d4d4;
+}
+
 /* --- Grid Container --- */
 
 #grid-container {
   display: grid;
   width: 100vw;
-  height: 100vh;
+  height: calc(100vh - 33px); /* 32px tab bar + 1px border */
   gap: 0;
   background-color: var(--bg-color);
   overflow: hidden;

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -171,5 +171,20 @@ export interface LayoutState {
   grid_template_rows: string;
 }
 
+// ---------------------------------------------------------------------------
+// Workspace API types (daemon/server/api.go)
+// ---------------------------------------------------------------------------
+
+/** Metadata for a single workspace. */
+export interface WorkspaceInfo {
+  /** Unique workspace identifier. */
+  id: string;
+  /** Human-readable display name (e.g. "Workspace 1"). */
+  name: string;
+}
+
+/** Response from GET /api/workspaces — list of workspace IDs with layout data. */
+export type WorkspaceListResponse = string[];
+
 // Ensure this file is treated as a module (required when using `declare global`).
 export {};

--- a/app/src/workspace.ts
+++ b/app/src/workspace.ts
@@ -1,0 +1,443 @@
+/**
+ * WorkspaceManager -- manages workspace tabs and their lifecycle.
+ *
+ * Responsibilities:
+ *   - Render and maintain the tab bar UI
+ *   - Track workspace list and active workspace
+ *   - Fire callbacks on switch/create/close/rename events
+ *   - Persist active workspace ID to localStorage
+ *
+ * Does NOT manage terminals or panel grid directly -- delegates to callbacks.
+ */
+
+import type { WorkspaceInfo } from "./types";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_WORKSPACES = 8;
+const ACTIVE_WORKSPACE_KEY = "zplex:activeWorkspace";
+
+// ---------------------------------------------------------------------------
+// Callback types
+// ---------------------------------------------------------------------------
+
+/** Fired when the user switches to a different workspace. */
+export type OnSwitchCallback = (fromId: string, toId: string) => void;
+
+/** Fired when a new workspace is created. */
+export type OnCreateCallback = (workspace: WorkspaceInfo) => void;
+
+/** Fired when a workspace close is requested. Returns a promise that resolves when close is complete. */
+export type OnCloseCallback = (workspaceId: string) => Promise<void>;
+
+/** Fired when a workspace is renamed. */
+export type OnRenameCallback = (workspaceId: string, newName: string) => void;
+
+// ---------------------------------------------------------------------------
+// WorkspaceManager
+// ---------------------------------------------------------------------------
+
+export class WorkspaceManager {
+  private readonly tabsContainer: HTMLElement;
+  private readonly addButton: HTMLElement;
+
+  /** Ordered list of workspaces. */
+  private readonly workspaces: WorkspaceInfo[] = [];
+
+  /** Currently active workspace ID. */
+  private activeId: string = "";
+
+  /** Counter for auto-naming. */
+  private nextNumber: number = 1;
+
+  /** Callbacks. */
+  private onSwitchCallback: OnSwitchCallback | null = null;
+  private onCreateCallback: OnCreateCallback | null = null;
+  private onCloseCallback: OnCloseCallback | null = null;
+  private onRenameCallback: OnRenameCallback | null = null;
+
+  constructor() {
+    const tabsContainer = document.getElementById("tab-bar-tabs");
+    if (!tabsContainer) {
+      throw new Error("tab-bar-tabs element not found in DOM");
+    }
+    this.tabsContainer = tabsContainer;
+
+    const addButton = document.getElementById("tab-bar-add");
+    if (!addButton) {
+      throw new Error("tab-bar-add element not found in DOM");
+    }
+    this.addButton = addButton;
+
+    // Wire up "+" button
+    this.addButton.addEventListener("click", () => {
+      this.createWorkspace();
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Callback registration
+  // -------------------------------------------------------------------------
+
+  onSwitch(callback: OnSwitchCallback): void {
+    this.onSwitchCallback = callback;
+  }
+
+  onCreate(callback: OnCreateCallback): void {
+    this.onCreateCallback = callback;
+  }
+
+  onClose(callback: OnCloseCallback): void {
+    this.onCloseCallback = callback;
+  }
+
+  onRename(callback: OnRenameCallback): void {
+    this.onRenameCallback = callback;
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /** Get the active workspace ID. */
+  getActiveId(): string {
+    return this.activeId;
+  }
+
+  /** Get the number of workspaces. */
+  getCount(): number {
+    return this.workspaces.length;
+  }
+
+  /** Get all workspace IDs (read-only snapshot). */
+  getWorkspaceIds(): readonly string[] {
+    return this.workspaces.map((w) => w.id);
+  }
+
+  /** Get workspace info by ID. */
+  getWorkspace(id: string): WorkspaceInfo | undefined {
+    return this.workspaces.find((w) => w.id === id);
+  }
+
+  /**
+   * Initialize workspaces from a list of known workspace IDs (from daemon).
+   * If the list is empty, creates a default "Workspace 1".
+   * Restores active workspace from localStorage if available.
+   */
+  initFromList(workspaceIds: string[]): void {
+    console.warn("[workspace] initFromList entry:", workspaceIds);
+
+    if (workspaceIds.length === 0) {
+      // No existing workspaces -- create default
+      this.addWorkspaceInternal("workspace-1", "Workspace 1");
+      this.nextNumber = 2;
+    } else {
+      // Populate from daemon data
+      let maxNum = 0;
+      for (const id of workspaceIds) {
+        // Try to extract number from ID for auto-naming continuity
+        const match = id.match(/^workspace-(\d+)$/);
+        const num = match ? parseInt(match[1], 10) : 0;
+        if (num > maxNum) {
+          maxNum = num;
+        }
+        const name = match ? `Workspace ${num}` : id;
+        this.addWorkspaceInternal(id, name);
+      }
+      this.nextNumber = maxNum + 1;
+    }
+
+    // Determine which workspace to activate
+    const savedActiveId = localStorage.getItem(ACTIVE_WORKSPACE_KEY);
+    const targetId =
+      savedActiveId && this.workspaces.some((w) => w.id === savedActiveId)
+        ? savedActiveId
+        : this.workspaces[0].id;
+
+    this.setActive(targetId);
+    this.renderTabs();
+
+    console.warn("[workspace] initFromList exit, active:", this.activeId);
+  }
+
+  /**
+   * Create a new workspace with auto-generated name.
+   * Returns the new workspace info, or null if at max capacity.
+   */
+  createWorkspace(): WorkspaceInfo | null {
+    console.warn("[workspace] createWorkspace entry");
+
+    if (this.workspaces.length >= MAX_WORKSPACES) {
+      console.warn(
+        "[workspace] max workspace count (8) reached, ignoring new workspace request",
+      );
+      return null;
+    }
+
+    const num = this.nextNumber;
+    this.nextNumber++;
+    const id = `workspace-${num}`;
+    const name = `Workspace ${num}`;
+
+    const workspace = this.addWorkspaceInternal(id, name);
+
+    if (this.onCreateCallback) {
+      this.onCreateCallback(workspace);
+    }
+
+    // Switch to the new workspace
+    this.switchTo(id);
+
+    console.warn("[workspace] createWorkspace exit:", id);
+    return workspace;
+  }
+
+  /**
+   * Switch to a workspace by ID. Fires the onSwitch callback.
+   */
+  switchTo(targetId: string): void {
+    console.warn("[workspace] switchTo entry:", targetId);
+
+    if (targetId === this.activeId) {
+      console.warn("[workspace] switchTo: already active, skipping");
+      return;
+    }
+
+    const target = this.workspaces.find((w) => w.id === targetId);
+    if (!target) {
+      console.error("[workspace] switchTo: workspace not found:", targetId);
+      return;
+    }
+
+    const fromId = this.activeId;
+    this.setActive(targetId);
+    this.renderTabs();
+
+    if (this.onSwitchCallback) {
+      this.onSwitchCallback(fromId, targetId);
+    }
+
+    console.warn("[workspace] switchTo exit:", targetId);
+  }
+
+  /**
+   * Switch to the next workspace (wraps around).
+   */
+  switchNext(): void {
+    if (this.workspaces.length <= 1) return;
+    const currentIdx = this.workspaces.findIndex(
+      (w) => w.id === this.activeId,
+    );
+    const nextIdx = (currentIdx + 1) % this.workspaces.length;
+    this.switchTo(this.workspaces[nextIdx].id);
+  }
+
+  /**
+   * Switch to the previous workspace (wraps around).
+   */
+  switchPrevious(): void {
+    if (this.workspaces.length <= 1) return;
+    const currentIdx = this.workspaces.findIndex(
+      (w) => w.id === this.activeId,
+    );
+    const prevIdx =
+      (currentIdx - 1 + this.workspaces.length) % this.workspaces.length;
+    this.switchTo(this.workspaces[prevIdx].id);
+  }
+
+  /**
+   * Request to close a workspace. Fires onClose callback for session cleanup.
+   */
+  async closeWorkspace(workspaceId: string): Promise<void> {
+    console.warn("[workspace] closeWorkspace entry:", workspaceId);
+
+    // Last workspace cannot be closed
+    if (this.workspaces.length <= 1) {
+      console.warn("[workspace] closeWorkspace: cannot close last workspace");
+      return;
+    }
+
+    const idx = this.workspaces.findIndex((w) => w.id === workspaceId);
+    if (idx === -1) {
+      console.error(
+        "[workspace] closeWorkspace: workspace not found:",
+        workspaceId,
+      );
+      return;
+    }
+
+    // Fire close callback (app.ts handles session cleanup + dialog)
+    if (this.onCloseCallback) {
+      await this.onCloseCallback(workspaceId);
+    }
+
+    // Remove workspace from list
+    this.workspaces.splice(idx, 1);
+
+    // If we closed the active workspace, switch to an adjacent one
+    if (this.activeId === workspaceId) {
+      const newIdx = Math.min(idx, this.workspaces.length - 1);
+      this.setActive(this.workspaces[newIdx].id);
+    }
+
+    this.renderTabs();
+
+    console.warn("[workspace] closeWorkspace exit:", workspaceId);
+  }
+
+  /**
+   * Remove a workspace from the internal list without firing callbacks.
+   * Used when the close callback has already handled cleanup externally.
+   */
+  removeWorkspaceInternal(workspaceId: string): void {
+    const idx = this.workspaces.findIndex((w) => w.id === workspaceId);
+    if (idx === -1) return;
+    this.workspaces.splice(idx, 1);
+
+    if (this.activeId === workspaceId && this.workspaces.length > 0) {
+      const newIdx = Math.min(idx, this.workspaces.length - 1);
+      this.setActive(this.workspaces[newIdx].id);
+    }
+
+    this.renderTabs();
+  }
+
+  // -------------------------------------------------------------------------
+  // Private methods
+  // -------------------------------------------------------------------------
+
+  /** Add a workspace to the internal list (no callbacks, no render). */
+  private addWorkspaceInternal(id: string, name: string): WorkspaceInfo {
+    const workspace: WorkspaceInfo = { id, name };
+    this.workspaces.push(workspace);
+    return workspace;
+  }
+
+  /** Set the active workspace and persist to localStorage. */
+  private setActive(id: string): void {
+    this.activeId = id;
+    localStorage.setItem(ACTIVE_WORKSPACE_KEY, id);
+  }
+
+  /** Render (or re-render) all tabs in the tab bar. */
+  private renderTabs(): void {
+    // Clear existing tabs
+    while (this.tabsContainer.firstChild) {
+      this.tabsContainer.removeChild(this.tabsContainer.firstChild);
+    }
+
+    const isLastWorkspace = this.workspaces.length <= 1;
+
+    for (const workspace of this.workspaces) {
+      const tab = document.createElement("div");
+      tab.classList.add("workspace-tab");
+      tab.dataset.workspaceId = workspace.id;
+
+      if (workspace.id === this.activeId) {
+        tab.classList.add("active");
+      }
+
+      // Name span
+      const nameSpan = document.createElement("span");
+      nameSpan.classList.add("workspace-tab-name");
+      nameSpan.textContent = workspace.name;
+
+      // Close button
+      const closeBtn = document.createElement("button");
+      closeBtn.classList.add("workspace-tab-close");
+      if (isLastWorkspace) {
+        closeBtn.classList.add("hidden");
+      }
+      closeBtn.textContent = "\u00d7"; // multiplication sign as close icon
+      closeBtn.title = "Close workspace";
+
+      tab.appendChild(nameSpan);
+      tab.appendChild(closeBtn);
+
+      // Click tab to switch
+      tab.addEventListener("click", (e: Event) => {
+        // Don't switch if clicking the close button
+        if (
+          (e.target as HTMLElement).classList.contains("workspace-tab-close")
+        ) {
+          return;
+        }
+        this.switchTo(workspace.id);
+      });
+
+      // Double-click name to rename
+      nameSpan.addEventListener("dblclick", (e: Event) => {
+        e.stopPropagation();
+        this.startRename(workspace.id, nameSpan);
+      });
+
+      // Close button click
+      closeBtn.addEventListener("click", (e: Event) => {
+        e.stopPropagation();
+        this.closeWorkspace(workspace.id).catch((err: unknown) => {
+          console.error("[workspace] closeWorkspace failed:", err);
+        });
+      });
+
+      this.tabsContainer.appendChild(tab);
+    }
+  }
+
+  /** Enter inline rename mode for a workspace tab. */
+  private startRename(workspaceId: string, nameSpan: HTMLElement): void {
+    console.warn("[workspace] startRename:", workspaceId);
+
+    const workspace = this.workspaces.find((w) => w.id === workspaceId);
+    if (!workspace) return;
+
+    const input = document.createElement("input");
+    input.classList.add("workspace-tab-input");
+    input.type = "text";
+    input.value = workspace.name;
+
+    // Replace name span with input
+    const parent = nameSpan.parentElement;
+    if (!parent) return;
+    parent.replaceChild(input, nameSpan);
+    input.focus();
+    input.select();
+
+    // Guard against finishRename being called twice (Enter fires blur as well)
+    let finished = false;
+
+    const finishRename = (accept: boolean): void => {
+      if (finished) return;
+      finished = true;
+
+      const newName = input.value.trim();
+      if (accept && newName.length > 0 && newName !== workspace.name) {
+        workspace.name = newName;
+        if (this.onRenameCallback) {
+          this.onRenameCallback(workspaceId, newName);
+        }
+      }
+      // Restore name span with current (possibly updated) name
+      nameSpan.textContent = workspace.name;
+      parent.replaceChild(nameSpan, input);
+    };
+
+    input.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        finishRename(true);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        finishRename(false);
+      }
+    });
+
+    input.addEventListener("blur", () => {
+      // Accept on blur (like VS Code behavior)
+      finishRename(true);
+    });
+  }
+}
+
+export { MAX_WORKSPACES, ACTIVE_WORKSPACE_KEY };

--- a/daemon/server/api.go
+++ b/daemon/server/api.go
@@ -314,6 +314,57 @@ func (s *Server) handlePutLayout(w http.ResponseWriter, r *http.Request) {
 }
 
 // ---------------------------------------------------------------------------
+// Workspace endpoints
+// ---------------------------------------------------------------------------
+
+// handleListWorkspaces returns the list of workspace IDs that have layout data.
+func (s *Server) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
+	slog.Info("server.handleListWorkspaces: listing workspaces")
+
+	s.layoutMu.Lock()
+	ids := make([]string, 0, len(s.layouts))
+	for id := range s.layouts {
+		ids = append(ids, id)
+	}
+	s.layoutMu.Unlock()
+
+	slog.Info("server.handleListWorkspaces: returning workspaces",
+		slog.Int("count", len(ids)),
+	)
+
+	writeJSON(w, http.StatusOK, ids)
+}
+
+// handleDeleteWorkspace removes the layout data for a specific workspace.
+func (s *Server) handleDeleteWorkspace(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	slog.Info("server.handleDeleteWorkspace: deleting workspace layout",
+		slog.String("workspace", id),
+	)
+
+	s.layoutMu.Lock()
+	_, exists := s.layouts[id]
+	if exists {
+		delete(s.layouts, id)
+	}
+	s.layoutMu.Unlock()
+
+	if !exists {
+		slog.Warn("server.handleDeleteWorkspace: workspace not found",
+			slog.String("workspace", id),
+		)
+		writeError(w, http.StatusNotFound, "workspace not found")
+		return
+	}
+
+	slog.Info("server.handleDeleteWorkspace: workspace layout deleted",
+		slog.String("workspace", id),
+	)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ---------------------------------------------------------------------------
 // JSON response helpers
 // ---------------------------------------------------------------------------
 

--- a/daemon/server/api.go
+++ b/daemon/server/api.go
@@ -243,14 +243,25 @@ func (s *Server) handlePatchSession(w http.ResponseWriter, r *http.Request) {
 // Layout endpoints
 // ---------------------------------------------------------------------------
 
-// handleGetLayout returns the current layout state.
-// Returns HTTP 200 with empty state if no layout has been saved.
+// handleGetLayout returns the layout state for a workspace.
+// The workspace is determined by the ?workspace= query parameter (default: "default").
+// Returns HTTP 200 with empty state if no layout has been saved for the workspace.
 func (s *Server) handleGetLayout(w http.ResponseWriter, r *http.Request) {
-	slog.Info("server.handleGetLayout: retrieving layout")
+	workspace := r.URL.Query().Get("workspace")
+	if workspace == "" {
+		workspace = "default"
+	}
+	slog.Info("server.handleGetLayout: retrieving layout",
+		slog.String("workspace", workspace),
+	)
 
 	s.layoutMu.Lock()
-	state := s.layout
+	state, exists := s.layouts[workspace]
 	s.layoutMu.Unlock()
+
+	if !exists {
+		state = layoutState{}
+	}
 
 	// Ensure panels is never null in JSON output
 	if state.Panels == nil {
@@ -258,15 +269,23 @@ func (s *Server) handleGetLayout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	slog.Info("server.handleGetLayout: layout retrieved",
+		slog.String("workspace", workspace),
 		slog.Int("panels", len(state.Panels)),
 	)
 
 	writeJSON(w, http.StatusOK, state)
 }
 
-// handlePutLayout saves a new layout state, replacing any previous state.
+// handlePutLayout saves a new layout state for a workspace, replacing any previous state.
+// The workspace is determined by the ?workspace= query parameter (default: "default").
 func (s *Server) handlePutLayout(w http.ResponseWriter, r *http.Request) {
-	slog.Info("server.handlePutLayout: processing layout save")
+	workspace := r.URL.Query().Get("workspace")
+	if workspace == "" {
+		workspace = "default"
+	}
+	slog.Info("server.handlePutLayout: processing layout save",
+		slog.String("workspace", workspace),
+	)
 
 	var state layoutState
 	if err := json.NewDecoder(r.Body).Decode(&state); err != nil {
@@ -283,10 +302,11 @@ func (s *Server) handlePutLayout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.layoutMu.Lock()
-	s.layout = state
+	s.layouts[workspace] = state
 	s.layoutMu.Unlock()
 
 	slog.Info("server.handlePutLayout: layout saved",
+		slog.String("workspace", workspace),
 		slog.Int("panels", len(state.Panels)),
 	)
 

--- a/daemon/server/router.go
+++ b/daemon/server/router.go
@@ -29,8 +29,8 @@ type Server struct {
 	mgr       *session.SessionManager
 	startTime time.Time
 	version   string
-	layoutMu  sync.Mutex
-	layout    layoutState
+	layoutMu sync.Mutex
+	layouts  map[string]layoutState // key = workspace ID
 }
 
 // NewServer creates a Server wired to the given session manager. The returned
@@ -42,6 +42,7 @@ func NewServer(mgr *session.SessionManager) *Server {
 		mgr:       mgr,
 		startTime: time.Now(),
 		version:   "0.1.0",
+		layouts:   make(map[string]layoutState),
 	}
 }
 

--- a/daemon/server/router.go
+++ b/daemon/server/router.go
@@ -61,6 +61,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/layout", s.handleGetLayout)
 	mux.HandleFunc("PUT /api/layout", s.handlePutLayout)
 
+	mux.HandleFunc("GET /api/workspaces", s.handleListWorkspaces)
+	mux.HandleFunc("DELETE /api/workspaces/{id}", s.handleDeleteWorkspace)
+
 	mux.HandleFunc("GET /ws/{session_id}", s.handleWebSocket)
 
 	// Middleware chain: CORS wraps logging wraps routing.

--- a/docs/zplex-project-plan.md
+++ b/docs/zplex-project-plan.md
@@ -184,6 +184,7 @@ zplex/
 │       ├── app.ts              # App init, session management, event handling
 │       ├── terminal.ts         # xterm.js wrapper: create, connect, reconnect
 │       ├── layout.ts           # Panel grid: add/remove/resize panels
+│       ├── workspace.ts        # Workspace tab bar: create/switch/close/rename workspaces
 │       ├── styles.css          # CSS Grid layout + dark theme
 │       └── types.ts            # Shared TypeScript types
 │
@@ -205,7 +206,7 @@ zplex/
 
 ## 5. Milestones
 
-> **Progress (2026-04-11):** M1 complete — all three issues (#1, #2, #5) are merged and closed. The Go daemon is functional (session CRUD, PTY/ConPTY, REST API, WebSocket I/O relay, ring buffer replay) and the Electron shell with xterm.js frontend is working (single panel, session reconnect). Next step: M2 — multi-panel layout with CSS Grid.
+> **Progress (2026-04-11):** M1 complete — all three issues (#1, #2, #5) are merged and closed. The Go daemon is functional (session CRUD, PTY/ConPTY, REST API, WebSocket I/O relay, ring buffer replay) and the Electron shell with xterm.js frontend is working (single panel, session reconnect). M2 in progress — #11 (workspace tab bar + dispose/recreate switching) is done; remaining M2 issues (multi-panel layout, panel resize, layout persistence) are planned.
 >
 > Note: The original plan's single "Go daemon" issue was split into #1 (session+PTY) and #2 (HTTP+WebSocket) during implementation. Issue #5 was delivered via PR #6. Remaining issues use TBD as they haven't been filed on GitHub yet.
 
@@ -236,6 +237,7 @@ zplex/
 | TBD | Frontend: multi-panel layout with CSS Grid | Add panel (button + keyboard shortcut), remove panel, CSS Grid dynamic columns/rows, each panel is an xterm.js instance connected to a separate daemon session | Planned | M1 |
 | TBD | Panel resize + keyboard navigation | Drag-to-resize panel borders, keyboard shortcuts (Ctrl+Shift+Arrow to navigate, Ctrl+Shift+N to new panel), focus indicator (highlighted border) | Planned | multi-panel |
 | TBD | Layout persistence | Save panel layout + session mapping to daemon (GET/PUT /api/layout). On reconnect, restore exact panel arrangement | Planned | panel resize |
+| #11 | Workspace tab bar + dispose/recreate switching | Tab bar UI, WorkspaceManager, dispose/recreate xterm.js on workspace switch, workspace CRUD API, layout per workspace | ✅ Done | layout persistence |
 
 **Demo scenario after M2:**
 1. Open zplex → one panel
@@ -315,6 +317,7 @@ zpit (running inside zplex's fixed panel)
 | TBD | Electron: auto-start daemon lifecycle | On app launch: check if daemon already running → connect. If not → spawn daemon. On app "Quit" (not close): offer to stop daemon or keep running | Planned | system tray |
 | TBD | electron-builder: Windows installer (.exe) | Build script: compile Go daemon for Windows amd64, bundle with Electron, produce NSIS installer. Include desktop shortcut and start menu entry | Planned | daemon lifecycle |
 | TBD | UX polish: theme, fonts, welcome screen | Dark theme matching zpit aesthetic. Monospace font selection. Welcome screen when no sessions exist (instructions + quick-start button) | Planned | installer |
+| TBD | Settings page | User preferences UI: theme selection, font configuration, keyboard shortcut customization, workspace defaults | Planned | system tray |
 
 ---
 


### PR DESCRIPTION
## Summary

Implements workspace tab bar with dispose/recreate switching mechanism, per-workspace layout API, and full keyboard shortcut support.

- **Tab bar UI**: Fixed 32px tab bar at window top with active (#007acc) / inactive (#2d2d2d) styling, close [x] buttons, "+" new workspace button, and double-click-to-rename
- **WorkspaceManager** (`workspace.ts`): New module managing workspace lifecycle — create, switch, close, rename — with callback-driven architecture decoupled from terminal/grid management
- **Dispose/Recreate switching**: On workspace switch, all xterm.js instances are disposed (freeing memory + WebGL contexts); target workspace panels are recreated from daemon layout data with ring buffer replay for near-instant recovery
- **Daemon API extensions**: `GET/PUT /api/layout` now accepts `?workspace={id}` query param (backward compatible, defaults to "default"); new `GET /api/workspaces` and `DELETE /api/workspaces/{id}` endpoints; internal storage changed from single `layoutState` to `map[string]layoutState`
- **Keyboard shortcuts**: `Ctrl+Shift+T` (new workspace), `Ctrl+Shift+PageUp/PageDown` (switch with wrap-around)
- **Persistence**: Active workspace ID stored in `localStorage` key `zplex:activeWorkspace`, restored on app restart
- **Guards**: Max 8 workspaces, last workspace cannot be closed, AC-8 protection for last panel in last workspace

### Files changed
| File | Change |
|------|--------|
| `app/src/types.ts` | Added `WorkspaceInfo`, `WorkspaceListResponse` types |
| `app/src/workspace.ts` | **New** — WorkspaceManager class |
| `app/src/index.html` | Added tab bar HTML structure |
| `app/src/styles.css` | Added tab bar CSS, adjusted grid container height |
| `app/src/layout.ts` | Added `disposeAllPanels()` method |
| `app/src/app.ts` | Integrated WorkspaceManager, workspace switching, keyboard shortcuts, init restore |
| `daemon/server/api.go` | Layout storage to map, workspace query param, workspace list/delete handlers |
| `daemon/server/router.go` | Registered workspace routes, updated Server struct |
| `CLAUDE.md` | Documented workspace shortcuts, architecture, limits |
| `docs/zplex-project-plan.md` | Updated M2 milestone, repo structure, settings page planning |

## Test plan

- [x] Start daemon + app: verify single "Workspace 1" tab appears with active styling
- [x] Click "+" on tab bar: verify new "Workspace 2" tab created and switched to
- [x] Press `Ctrl+Shift+T`: verify new workspace created
- [x] Click between tabs: verify panel dispose/recreate with ring buffer replay
- [x] Press `Ctrl+Shift+PageDown` / `Ctrl+Shift+PageUp`: verify wrap-around switching
- [x] Double-click tab name: verify inline rename with Enter/Escape
- [x] Close workspace with running sessions: verify dialog appears
- [x] Verify last workspace [x] button is hidden
- [x] Verify `Ctrl+Shift+W` on last panel in last workspace is blocked
- [x] Restart app: verify active workspace restored from localStorage
- [x] `GET /api/workspaces`: verify returns workspace ID list
- [x] `GET /api/layout?workspace=workspace-1`: verify per-workspace layout
- [x] `DELETE /api/workspaces/workspace-1`: verify 204 response
- [x] Verify max 8 workspaces limit with console warning
- [x] Go daemon builds: `go build ./...`
- [x] TypeScript compiles: `npx tsc --noEmit`

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
