### PR TITLE
[M3] zpit fixed panel: daemon auto-launch + frontend cockpit layout (#13)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,17 @@ The frontend supports multiple workspaces, each with its own set of terminal pan
 - **Active workspace persistence**: Current workspace ID stored in `localStorage` key `zplex:activeWorkspace` (pure UI state — kept in the frontend). Restored on app restart.
 - **Close workspace**: Shows confirmation dialog if workspace has running sessions. The remembered detach/kill choice for both panel close and workspace close is owned by the daemon and persisted to `~/.zplex/preferences.json` via `GET/PUT /api/preferences` (loaded once at startup into a frontend cache). Last workspace cannot be closed.
 
+### Fixed zpit Cockpit Panel
+
+The terminal area is wrapped in `#main-split` = `[#fixed-panel-area] [#v-splitter] [#grid-container]`. The zpit cockpit terminal mounts into `#fixed-panel-area` and is never part of `PanelGrid` — auto-tile, gutter resize, focus navigation, and layout persistence are entirely untouched.
+
+Key behaviors:
+
+- **Global persistence**: the fixed panel is created once at init and survives workspace switch and workspace close — it is visible in every workspace.
+- **Exit overlay**: when zpit exits, the fixed panel shows a `zpit exited` overlay with a manual `Restart` button. There is NO auto-restart.
+- **Graceful fallback**: when `[zpit].enabled` is false or the binary is missing, the daemon creates no fixed session and the frontend falls back to the pure dynamic grid (M2 behavior). `#main-split` carries class `no-fixed`, which hides `#fixed-panel-area` and `#v-splitter`.
+- **Split ratio**: the fixed/dynamic split ratio is pure UI state stored in `localStorage` key `zplex:fixedPanelRatio` (default `0.35`). It is NOT in daemon preferences.
+
 ### Keyboard Shortcuts
 
 | Shortcut | Action |
@@ -113,7 +124,7 @@ The frontend supports multiple workspaces, each with its own set of terminal pan
 | `Ctrl+Shift+N` | Create new terminal panel |
 | `Ctrl+Shift+T` | Create new workspace tab |
 | `Ctrl+Shift+W` | Close focused panel (shows dialog or uses saved preference) |
-| `Ctrl+Shift+Arrow` | Move focus to adjacent panel (Up/Down/Left/Right) |
+| `Ctrl+Shift+Arrow` | Move focus to adjacent panel (Up/Down/Left/Right); `Ctrl+Shift+Left` from the leftmost grid panel crosses into the zpit fixed panel, and `Ctrl+Shift+Right` from the zpit fixed panel crosses back to the leftmost grid panel |
 | `Ctrl+Shift+PageUp` | Switch to previous workspace (wraps around) |
 | `Ctrl+Shift+PageDown` | Switch to next workspace (wraps around) |
 | `Shift+Click [×]` | Force close dialog (override saved preference) |
@@ -124,17 +135,22 @@ The frontend supports multiple workspaces, each with its own set of terminal pan
 |--------|------|---------|
 | GET | `/api/health` | Health check + version |
 | GET/POST | `/api/sessions` | List / create sessions |
-| GET/DELETE/PATCH | `/api/sessions/{id}` | Get / kill / update session |
+| GET/DELETE/PATCH | `/api/sessions/{id}` | Get / kill / update session; DELETE returns HTTP 403 for the fixed (`kind=="fixed"`) session — it cannot be killed from the UI |
 | GET/PUT | `/api/layout` | Get / save panel layout (per workspace) |
 | GET | `/api/workspaces` | List workspace IDs with layout data |
 | DELETE | `/api/workspaces/{id}` | Delete workspace layout data |
 | GET/PUT | `/api/preferences` | Get / save app-managed user preferences (close behavior), persisted to `~/.zplex/preferences.json` |
 | GET | `/api/events` | SSE stream for real-time updates |
+| POST | `/api/zpit/restart` | Kill (if running) and relaunch the fixed zpit session |
 
 ### WebSocket Protocol (`/ws/{session_id}`)
 
 - Client→Server: `{ type: "input", data: "..." }` or `{ type: "resize", cols: N, rows: N }`
 - Server→Client: `{ type: "output", data: "..." }` or `{ type: "exit", code: N }`
+
+### SessionInfo `kind` field
+
+`SessionInfo` (and `Session`) carry a `kind` field in all `GET /api/sessions` and `GET /api/sessions/{id}` responses: `""` for normal/agent sessions, `"fixed"` for the zpit cockpit session.
 
 ## Tech Stack Constraints
 
@@ -161,7 +177,18 @@ The frontend supports multiple workspaces, each with its own set of terminal pan
 
 ## Configuration
 
-zplex config lives at `~/.zplex/config.toml`. Key sections: `[daemon]` (port, default_shell, buffer_size), `[zpit]` (auto-create fixed panel), `[electron]` (tray behavior, daemon lifecycle), `[appearance]` (theme, font). This file is **read-only** to the daemon (loaded once at startup; user hand-edited).
+zplex config lives at `~/.zplex/config.toml`. Key sections: `[daemon]` (port, default_shell, buffer_size), `[zpit]` (see below), `[electron]` (tray behavior, daemon lifecycle), `[appearance]` (theme, font). This file is **read-only** to the daemon (loaded once at startup; user hand-edited).
+
+**`[zpit]` section keys:**
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | bool | `true` | Auto-launch the cockpit fixed panel on daemon startup |
+| `bin` | string | `"zpit"` | Binary name or path; resolved via PATH when not absolute |
+| `config` | string | `""` | Optional path injected as the `ZPIT_CONFIG` env var; omitted when empty |
+| `args` | string array | `[]` | Extra arguments passed to the binary |
+
+The daemon does NOT parse zpit's own TOML — it only spawns the binary and optionally sets `ZPIT_CONFIG`.
 
 App-managed mutable preferences (currently close behavior) live separately in `~/.zplex/preferences.json`, owned by the daemon's `prefs` package and read/written at runtime via `GET/PUT /api/preferences`. Kept apart from `config.toml` so runtime writes never clobber the user's hand-edited TOML.
 

--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -14,6 +14,7 @@
 import { TerminalWrapper } from "./terminal";
 import { PanelGrid } from "./layout";
 import { WorkspaceManager } from "./workspace";
+import { FixedPanel } from "./fixedpanel";
 import type {
   SessionInfo,
   CreateSessionRequest,
@@ -63,6 +64,9 @@ function getWorkspaceRegistry(workspaceId: string): Map<string, TerminalWrapper>
 
 let panelGrid: PanelGrid | null = null;
 let wsManager: WorkspaceManager | null = null;
+let fixedPanel: FixedPanel | null = null;
+/** True when keyboard focus is currently on the zpit fixed panel (AC-14). */
+let fixedPanelFocused = false;
 
 /** Return the active workspace ID, falling back to DEFAULT_WORKSPACE_ID. */
 function activeWorkspaceId(): string {
@@ -212,10 +216,10 @@ function mountSessionToGrid(sessionId: string, title: string): void {
   const port = getDaemonPort();
   const wrapper = new TerminalWrapper(sessionId, port);
 
-  // Register focus callback: when terminal is clicked, set panel focus
+  // Register focus callback: when terminal is clicked, set panel focus.
+  // Also clears fixed-panel focus state (AC-14).
   wrapper.onFocus((id: string) => {
-    panelGrid?.setFocus(id);
-    wrapper.focusTerminal();
+    focusGridPanel(id);
   });
 
   // Register in workspace registry
@@ -225,10 +229,9 @@ function mountSessionToGrid(sessionId: string, title: string): void {
   // Mount xterm into the panel's content area
   wrapper.mount(panelInfo.contentElement);
 
-  // Wire up header click-to-focus
+  // Wire up header click-to-focus; also clears fixed-panel focus state (AC-14).
   panelInfo.headerElement.addEventListener("mousedown", () => {
-    panelGrid?.setFocus(sessionId);
-    wrapper.focusTerminal();
+    focusGridPanel(sessionId);
   });
 
   // Wire up close button [x] (AC-8, AC-10)
@@ -244,9 +247,8 @@ function mountSessionToGrid(sessionId: string, title: string): void {
     });
   }
 
-  // Set focus on the newly created panel
-  panelGrid.setFocus(sessionId);
-  wrapper.focusTerminal();
+  // Set focus on the newly created panel; also clears fixed-panel focus state.
+  focusGridPanel(sessionId);
 
   console.warn("[app] mountSessionToGrid exit:", sessionId);
 }
@@ -449,25 +451,55 @@ async function closePanelFlow(sessionId: string, forceDialog: boolean): Promise<
 // Focus navigation
 // ---------------------------------------------------------------------------
 
+/** Focus a dynamic-grid panel, clearing the fixed-panel focus state. */
+function focusGridPanel(sessionId: string): void {
+  fixedPanelFocused = false;
+  fixedPanel?.setFocusVisual(false);
+  panelGrid?.setFocus(sessionId);
+  getWorkspaceRegistry(activeWorkspaceId()).get(sessionId)?.focusTerminal();
+}
+
+/** Move keyboard focus onto the zpit fixed panel (AC-14). */
+function focusFixedPanel(): void {
+  fixedPanelFocused = true;
+  fixedPanel?.setFocusVisual(true);
+  fixedPanel?.focusTerminal();
+}
+
 /**
  * Move focus to the adjacent panel in the given direction.
- * If no adjacent panel exists, focus stays on the current panel.
+ * Handles cross-area navigation between the fixed panel and the dynamic grid
+ * (AC-14). Intra-grid navigation is unchanged.
  */
 function moveFocus(direction: "up" | "down" | "left" | "right"): void {
   if (!panelGrid) return;
 
+  // From the fixed panel, only Ctrl+Shift+Right crosses back into the grid.
+  if (fixedPanelFocused) {
+    if (direction === "right") {
+      const ids = panelGrid.getPanelIds();
+      if (ids.length > 0) {
+        focusGridPanel(ids[0]);
+      }
+    }
+    return;
+  }
+
   const currentId = panelGrid.getFocusedPanelId();
   if (!currentId) return;
 
+  // From the leftmost grid panel, Ctrl+Shift+Left crosses into the fixed panel.
+  if (direction === "left" && fixedPanel?.isActive()) {
+    const ids = panelGrid.getPanelIds();
+    if (ids.length > 0 && ids[0] === currentId) {
+      focusFixedPanel();
+      return;
+    }
+  }
+
   const adjacentId = panelGrid.getAdjacentPanelId(currentId, direction);
   if (!adjacentId) return;
-
-  panelGrid.setFocus(adjacentId);
-  const registry = getWorkspaceRegistry(activeWorkspaceId());
-  const wrapper = registry.get(adjacentId);
-  if (wrapper) {
-    wrapper.focusTerminal();
-  }
+  focusGridPanel(adjacentId);
 }
 
 // ---------------------------------------------------------------------------
@@ -502,9 +534,12 @@ async function handleWorkspaceSwitch(fromId: string, toId: string): Promise<void
     `/api/layout?workspace=${encodeURIComponent(toId)}`,
   );
 
-  // 4. Fetch running sessions for title lookup
+  // 4. Fetch running sessions for title lookup.
+  // Exclude the fixed zpit session from the dynamic grid (AC-10).
   const sessionList = await apiGet<SessionInfo[]>("/api/sessions");
-  const runningSessions = sessionList.filter((s) => s.status === "running");
+  const runningSessions = sessionList.filter(
+    (s) => s.status === "running" && s.kind !== "fixed",
+  );
   const runningIds = new Set(runningSessions.map((s) => s.id));
   const titleMap = new Map<string, string>();
   for (const s of runningSessions) {
@@ -558,8 +593,9 @@ async function handleWorkspaceClose(workspaceId: string): Promise<void> {
       `/api/layout?workspace=${encodeURIComponent(workspaceId)}`,
     );
     const sessionList = await apiGet<SessionInfo[]>("/api/sessions");
+    // Exclude the fixed zpit session from workspace close consideration (AC-10).
     const runningIds = new Set(
-      sessionList.filter((s) => s.status === "running").map((s) => s.id),
+      sessionList.filter((s) => s.status === "running" && s.kind !== "fixed").map((s) => s.id),
     );
     for (const panel of layoutState.panels) {
       if (runningIds.has(panel.session_id)) {
@@ -667,6 +703,13 @@ async function init(): Promise<void> {
   // Register resize callback for FitAddon
   panelGrid.onPanelResize(() => {
     refitAllTerminals();
+  });
+
+  // Create the fixed panel once at init (AC-9, AC-12). It is never disposed
+  // by workspace switches or closes — it persists for the app lifetime.
+  fixedPanel = new FixedPanel(getDaemonPort());
+  fixedPanel.onFocusRequest(() => {
+    fixedPanelFocused = true;
   });
 
   // NOTE: onLayoutChange callback is registered AFTER reconciliation completes
@@ -802,9 +845,18 @@ async function init(): Promise<void> {
   const activeWorkspace = wsManager.getActiveId();
   console.warn("[app] active workspace:", activeWorkspace);
 
-  // Fetch sessions and layout state for the active workspace
+  // Fetch sessions and layout state for the active workspace.
+  // Detect and mount the fixed zpit cockpit session first (AC-9, AC-10, AC-11).
   const sessionList = await apiGet<SessionInfo[]>("/api/sessions");
-  const runningSessions = sessionList.filter((s) => s.status === "running");
+  const fixedSession = sessionList.find((s) => s.kind === "fixed");
+  if (fixedSession && fixedPanel) {
+    fixedPanel.mount(fixedSession.id, fixedSession.status);
+  }
+  const hasFixed = fixedSession !== undefined;
+  // Exclude the fixed session from the dynamic-grid running set (AC-10).
+  const runningSessions = sessionList.filter(
+    (s) => s.status === "running" && s.kind !== "fixed",
+  );
   const layoutState = await apiGet<LayoutState>(
     `/api/layout?workspace=${encodeURIComponent(activeWorkspace)}`,
   );
@@ -880,10 +932,15 @@ async function init(): Promise<void> {
         "actual:", actualPanelCount, "), using auto-tiled grid");
     }
 
-    // If no panels were mounted at all, create a fresh one
+    // If no panels were mounted at all, create a fresh one (AC-11: skip when
+    // the fixed zpit cockpit is present — empty grid is intentional).
     if (mountedIds.size === 0) {
-      console.warn("[app] restore: no sessions survived reconciliation, creating initial session");
-      await createAndMountPanel("Terminal 1");
+      if (!hasFixed) {
+        console.warn("[app] restore: no sessions survived reconciliation, creating initial session");
+        await createAndMountPanel("Terminal 1");
+      } else {
+        console.warn("[app] restore: no dynamic sessions; empty grid is intentional because the fixed zpit cockpit is present");
+      }
     }
   } else if (runningSessions.length > 0) {
     // AC-9: No saved layout — fall back to default behavior
@@ -894,9 +951,15 @@ async function init(): Promise<void> {
       }
     }
   } else {
-    // No sessions and no layout — create a fresh one
-    console.warn("[app] no running sessions, creating initial session");
-    await createAndMountPanel("Terminal 1");
+    // No sessions and no layout.
+    if (!hasFixed) {
+      // Create a fresh terminal when no fixed zpit cockpit is present.
+      console.warn("[app] no running sessions, creating initial session");
+      await createAndMountPanel("Terminal 1");
+    } else {
+      // Fixed zpit cockpit is present — start with an empty dynamic grid (AC-11).
+      console.warn("[app] fixed zpit cockpit present; starting with empty dynamic grid");
+    }
   }
 
   // AC-10: Refit all terminals after reconciliation

--- a/app/src/fixedpanel.ts
+++ b/app/src/fixedpanel.ts
@@ -244,8 +244,9 @@ export class FixedPanel {
     this.wrapper?.dispose();
     this.wrapper = null;
 
+    // mountTerminal creates a fresh wrapper; TerminalWrapper.mount() performs
+    // the initial fit and installs a ResizeObserver, so no explicit fit here.
     this.mountTerminal(data.id);
-    this.wrapper?.fit();
   }
 
   /**

--- a/app/src/fixedpanel.ts
+++ b/app/src/fixedpanel.ts
@@ -1,0 +1,305 @@
+/**
+ * FixedPanel — persistent zpit cockpit panel.
+ *
+ * Manages the left-hand fixed panel that hosts the zpit TUI session.
+ * Unlike dynamic grid panels, this panel is created once at init and
+ * survives workspace switches and closures (AC-12).
+ *
+ * Layout: #main-split (flex row)
+ *   ├─ #fixed-panel-area   (this.fixedArea)  width = ratio%
+ *   ├─ #v-splitter         (this.splitter)   4px flex-none, draggable
+ *   └─ #grid-container     (this.gridContainer)  flex: 1
+ *
+ * The splitter drag adjusts the fixed area percentage; ratio is persisted to
+ * localStorage key "zplex:fixedPanelRatio" (AC-13).
+ */
+
+import { TerminalWrapper } from "./terminal";
+import type { CreateSessionResponse } from "./types";
+import { FIXED_PANEL_RATIO_KEY, DEFAULT_FIXED_PANEL_RATIO } from "./types";
+
+const MIN_PANEL_PX = 200;
+const SPLITTER_FALLBACK_PX = 4;
+
+export class FixedPanel {
+  private readonly daemonPort: number;
+
+  // TerminalWrapper for the live zpit session; null when exited or unmounted.
+  private wrapper: TerminalWrapper | null = null;
+
+  // Panel DOM elements built by mount(); null before mount.
+  private panelEl: HTMLElement | null = null;
+  private headerEl: HTMLElement | null = null;
+  private contentEl: HTMLElement | null = null;
+
+  // Top-level DOM anchors resolved in the constructor.
+  private readonly mainSplit: HTMLElement | null;
+  private readonly fixedArea: HTMLElement | null;
+  private readonly splitter: HTMLElement | null;
+  private readonly gridContainer: HTMLElement | null;
+
+  private active = false;
+  private focusRequestCb: (() => void) | null = null;
+
+  constructor(daemonPort: number) {
+    this.daemonPort = daemonPort;
+
+    this.mainSplit = document.getElementById("main-split");
+    this.fixedArea = document.getElementById("fixed-panel-area");
+    this.splitter = document.getElementById("v-splitter");
+    this.gridContainer = document.getElementById("grid-container");
+
+    if (!this.mainSplit || !this.fixedArea || !this.splitter || !this.gridContainer) {
+      console.error("[fixedpanel] required DOM elements not found (#main-split, #fixed-panel-area, #v-splitter, #grid-container)");
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Public API (T13 contract)
+  // ---------------------------------------------------------------------------
+
+  /** Whether a fixed session is currently mounted (cockpit active). */
+  isActive(): boolean {
+    return this.active;
+  }
+
+  /**
+   * Activate the cockpit for the given fixed session. Removes 'no-fixed' from
+   * #main-split, builds the header (label "zpit", no close button) + content,
+   * restores the persisted width ratio, and wires the #v-splitter drag.
+   * If status === "exited", shows the exited overlay instead of a live terminal.
+   * Call this exactly once at app init.
+   */
+  mount(sessionId: string, status: string): void {
+    if (!this.mainSplit || !this.fixedArea || !this.splitter || !this.gridContainer) {
+      console.error("[fixedpanel] mount: required DOM elements missing, aborting");
+      return;
+    }
+
+    // Reveal the fixed area by removing the hiding class.
+    this.mainSplit.classList.remove("no-fixed");
+
+    // Build panel DOM inside #fixed-panel-area.
+    const panelEl = document.createElement("div");
+    panelEl.classList.add("panel", "fixed-panel");
+
+    const headerEl = document.createElement("div");
+    headerEl.classList.add("panel-header");
+
+    const titleSpan = document.createElement("span");
+    titleSpan.classList.add("panel-title");
+    titleSpan.textContent = "zpit";
+    // No close button (AC-9).
+    headerEl.appendChild(titleSpan);
+
+    const contentEl = document.createElement("div");
+    contentEl.classList.add("panel-content");
+
+    panelEl.appendChild(headerEl);
+    panelEl.appendChild(contentEl);
+    this.fixedArea.appendChild(panelEl);
+
+    this.panelEl = panelEl;
+    this.headerEl = headerEl;
+    this.contentEl = contentEl;
+
+    // Click on panel → grant focus visual + notify app.ts.
+    panelEl.addEventListener("mousedown", () => {
+      this.setFocusVisual(true);
+      this.focusRequestCb?.();
+    });
+
+    // Restore persisted width ratio (AC-13).
+    const stored = localStorage.getItem(FIXED_PANEL_RATIO_KEY);
+    let ratio = stored !== null ? parseFloat(stored) : DEFAULT_FIXED_PANEL_RATIO;
+    if (isNaN(ratio)) {
+      ratio = DEFAULT_FIXED_PANEL_RATIO;
+    }
+    this.applyRatio(ratio);
+
+    // Wire splitter drag (AC-13).
+    this.wireSplitterDrag();
+
+    // Show live terminal or exited overlay.
+    if (status === "exited") {
+      this.showExited();
+    } else {
+      this.mountTerminal(sessionId);
+    }
+
+    this.active = true;
+  }
+
+  /** Focus the zpit terminal (used by cross-area Ctrl+Shift navigation). */
+  focusTerminal(): void {
+    this.wrapper?.focusTerminal();
+  }
+
+  /** Add/remove the focused visual style on the fixed panel. */
+  setFocusVisual(focused: boolean): void {
+    if (focused) {
+      this.panelEl?.classList.add("focused");
+    } else {
+      this.panelEl?.classList.remove("focused");
+    }
+  }
+
+  /** Register a callback fired when the fixed panel is clicked. */
+  onFocusRequest(callback: () => void): void {
+    this.focusRequestCb = callback;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Apply the fixed-area width ratio.
+   * Ratio is clamped to [0.05, 0.95] to keep both panes visible.
+   */
+  private applyRatio(ratio: number): void {
+    if (!this.fixedArea) return;
+    const clamped = Math.max(0.05, Math.min(0.95, ratio));
+    this.fixedArea.style.width = `${clamped * 100}%`;
+  }
+
+  /**
+   * Create and mount a TerminalWrapper for the given session into contentEl.
+   * Wires onFocus and onExit callbacks.
+   */
+  private mountTerminal(sessionId: string): void {
+    if (!this.contentEl) return;
+
+    // Clear any overlay from a previous exited state.
+    while (this.contentEl.firstChild) {
+      this.contentEl.removeChild(this.contentEl.firstChild);
+    }
+
+    const wrapper = new TerminalWrapper(sessionId, this.daemonPort);
+    this.wrapper = wrapper;
+
+    wrapper.onFocus(() => {
+      this.setFocusVisual(true);
+      this.focusRequestCb?.();
+      wrapper.focusTerminal();
+    });
+
+    wrapper.onExit(() => {
+      this.showExited();
+    });
+
+    wrapper.mount(this.contentEl);
+  }
+
+  /**
+   * Replace the terminal area with an exited overlay (AC-15).
+   * Disposes any live wrapper and shows a "zpit exited" message + Restart button.
+   */
+  private showExited(): void {
+    this.wrapper?.dispose();
+    this.wrapper = null;
+
+    if (!this.contentEl) return;
+
+    // Clear existing children (terminal or previous overlay).
+    while (this.contentEl.firstChild) {
+      this.contentEl.removeChild(this.contentEl.firstChild);
+    }
+
+    const overlay = document.createElement("div");
+    overlay.classList.add("fixed-exited-overlay");
+
+    const msg = document.createElement("span");
+    msg.textContent = "zpit exited";
+
+    const restartBtn = document.createElement("button");
+    restartBtn.textContent = "Restart";
+    restartBtn.addEventListener("click", () => {
+      this.restart().catch((err: unknown) => {
+        console.error("[fixedpanel] restart error:", err);
+      });
+    });
+
+    overlay.appendChild(msg);
+    overlay.appendChild(restartBtn);
+    this.contentEl.appendChild(overlay);
+  }
+
+  /**
+   * POST /api/zpit/restart and remount a new TerminalWrapper on 201 (AC-15).
+   */
+  private async restart(): Promise<void> {
+    const resp = await fetch(`http://localhost:${this.daemonPort}/api/zpit/restart`, {
+      method: "POST",
+    });
+
+    if (resp.status !== 201) {
+      console.error("[fixedpanel] restart failed:", resp.status);
+      return;
+    }
+
+    const data = await resp.json() as CreateSessionResponse;
+
+    // Dispose any existing wrapper (safety guard) before remounting.
+    this.wrapper?.dispose();
+    this.wrapper = null;
+
+    this.mountTerminal(data.id);
+    this.wrapper?.fit();
+  }
+
+  /**
+   * Wire pointer-event drag on #v-splitter to resize fixed/dynamic ratio (AC-13).
+   * Uses document-level pointermove/pointerup listeners, matching layout.ts pattern.
+   */
+  private wireSplitterDrag(): void {
+    if (!this.splitter) return;
+
+    this.splitter.addEventListener("pointerdown", (startEvent: PointerEvent) => {
+      if (!this.mainSplit || !this.fixedArea || !this.splitter) return;
+
+      this.splitter.setPointerCapture(startEvent.pointerId);
+      startEvent.preventDefault();
+
+      // Visual feedback during drag.
+      this.splitter.classList.add("dragging");
+
+      // Track the latest ratio so pointerup can persist it.
+      let currentRatio = DEFAULT_FIXED_PANEL_RATIO;
+
+      const onPointerMove = (e: PointerEvent): void => {
+        if (!this.mainSplit || !this.fixedArea || !this.splitter) return;
+
+        const rect = this.mainSplit.getBoundingClientRect();
+        const total = rect.width;
+        const splitterW = this.splitter.offsetWidth || SPLITTER_FALLBACK_PX;
+
+        // Guard: container too small to honour both minimum widths.
+        if (total - splitterW - 2 * MIN_PANEL_PX <= 0) return;
+
+        let fixedPx = e.clientX - rect.left;
+        fixedPx = Math.max(MIN_PANEL_PX, Math.min(fixedPx, total - splitterW - MIN_PANEL_PX));
+
+        currentRatio = fixedPx / total;
+        this.fixedArea.style.width = `${currentRatio * 100}%`;
+      };
+
+      const onPointerUp = (e: PointerEvent): void => {
+        if (!this.splitter) return;
+
+        this.splitter.releasePointerCapture(e.pointerId);
+        this.splitter.classList.remove("dragging");
+
+        document.removeEventListener("pointermove", onPointerMove);
+        document.removeEventListener("pointerup", onPointerUp);
+
+        // Persist ratio and refit terminal to new width.
+        localStorage.setItem(FIXED_PANEL_RATIO_KEY, String(currentRatio));
+        this.wrapper?.fit();
+      };
+
+      document.addEventListener("pointermove", onPointerMove);
+      document.addEventListener("pointerup", onPointerUp);
+    });
+  }
+}

--- a/app/src/index.html
+++ b/app/src/index.html
@@ -14,8 +14,14 @@
     <button id="tab-bar-add" title="New workspace (Ctrl+Shift+T)">+</button>
   </div>
 
-  <!-- Grid container: panels and gutters are inserted dynamically by layout.ts -->
-  <div id="grid-container"></div>
+  <!-- Terminal area: fixed zpit cockpit (left) + draggable splitter + dynamic grid (right). -->
+  <!-- #main-split starts with class "no-fixed"; app.ts removes it once a fixed zpit session is mounted. -->
+  <div id="main-split" class="no-fixed">
+    <div id="fixed-panel-area"></div>
+    <div id="v-splitter"></div>
+    <!-- Grid container: panels and gutters are inserted dynamically by layout.ts -->
+    <div id="grid-container"></div>
+  </div>
 
   <!-- Add panel button (AC-13) -->
   <button id="add-panel-btn" title="New panel (Ctrl+Shift+N)">+</button>

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -151,15 +151,94 @@ html, body {
   color: #d4d4d4;
 }
 
+/* --- Main split (fixed cockpit + dynamic grid) --- */
+
+#main-split {
+  display: flex;
+  flex-direction: row;
+  width: 100vw;
+  height: calc(100vh - 33px); /* 32px tab bar + 1px border */
+  overflow: hidden;
+}
+
+/* Left cockpit — width set inline by fixedpanel.ts; must not shrink */
+#fixed-panel-area {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+  overflow: hidden;
+}
+
+/* Draggable vertical divider */
+#v-splitter {
+  flex: 0 0 4px;
+  cursor: col-resize;
+  background-color: var(--gutter-color);
+}
+
+#v-splitter:hover,
+#v-splitter.dragging {
+  background-color: var(--gutter-hover-color);
+}
+
+/* Hide fixed area and splitter when no zpit session; grid fills full width */
+#main-split.no-fixed #fixed-panel-area,
+#main-split.no-fixed #v-splitter {
+  display: none;
+}
+
+/* Inner fixed panel fills the area */
+#fixed-panel-area .panel {
+  flex: 1 1 0;
+  min-height: 0;
+}
+
+/* AC-16: left accent border on fixed panel header (dynamic headers lack this) */
+#fixed-panel-area .panel-header {
+  border-left: 3px solid #4ec9b0;
+}
+
 /* --- Grid Container --- */
 
 #grid-container {
   display: grid;
-  width: 100vw;
-  height: calc(100vh - 33px); /* 32px tab bar + 1px border */
+  flex: 1 1 0;
+  min-width: 0;
+  height: 100%;
   gap: 0;
   background-color: var(--bg-color);
   overflow: hidden;
+}
+
+/* --- Fixed Panel Exited Overlay (AC-15) --- */
+
+.fixed-exited-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-size: 13px;
+}
+
+.fixed-exited-overlay button {
+  padding: 4px 16px;
+  border: 1px solid #4ec9b0;
+  border-radius: 3px;
+  background: #3c3c3c;
+  color: var(--text-color);
+  cursor: pointer;
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.fixed-exited-overlay button:hover {
+  background: #4c4c4c;
 }
 
 /* --- Panel --- */

--- a/app/src/terminal.ts
+++ b/app/src/terminal.ts
@@ -33,6 +33,7 @@ export class TerminalWrapper {
   private resizeObserver: ResizeObserver | null = null;
   private onFocusCallback: ((sessionId: string) => void) | null = null;
   private onDisposeCallback: ((sessionId: string) => void) | null = null;
+  private onExitCallback: ((code: number) => void) | null = null;
 
   constructor(sessionId: string, daemonPort: number) {
     this.sessionId = sessionId;
@@ -61,6 +62,11 @@ export class TerminalWrapper {
   /** Register a callback invoked when the terminal is disposed. */
   onDispose(callback: (sessionId: string) => void): void {
     this.onDisposeCallback = callback;
+  }
+
+  /** Register a callback invoked when the session's process exits (WS "exit"). */
+  onExit(callback: (code: number) => void): void {
+    this.onExitCallback = callback;
   }
 
   /** Trigger a re-fit of the terminal to its container dimensions. */
@@ -200,6 +206,9 @@ export class TerminalWrapper {
             "code:",
             msg.code,
           );
+          if (this.onExitCallback) {
+            this.onExitCallback(msg.code);
+          }
           break;
       }
     };

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -16,6 +16,7 @@ export interface SessionInfo {
   id: string;
   title: string;
   status: string; // "running" | "exited"
+  kind: string; // "" = normal/agent session, "fixed" = zpit cockpit
   created_at: string; // ISO 8601 timestamp
   pid: number;
   exit_code: number;
@@ -42,6 +43,16 @@ export interface HealthResponse {
   uptime: number;
   sessions: number;
 }
+
+// ---------------------------------------------------------------------------
+// Fixed panel UI state — localStorage keys and defaults (AC-13)
+// ---------------------------------------------------------------------------
+
+/** localStorage key for the persisted fixed-panel width ratio (AC-13). */
+export const FIXED_PANEL_RATIO_KEY = "zplex:fixedPanelRatio";
+
+/** Default fixed-panel width fraction when no value is persisted (AC-13). */
+export const DEFAULT_FIXED_PANEL_RATIO = 0.35;
 
 // ---------------------------------------------------------------------------
 // WebSocket message types (server/ws.go)

--- a/daemon/config/config.go
+++ b/daemon/config/config.go
@@ -21,16 +21,31 @@ const (
 	DefaultBufferSize = 102400
 )
 
+// Default values for zpit integration configuration.
+const (
+	DefaultZpitBin = "zpit"
+)
+
+// ZpitConfig holds configuration for the zpit integration.
+type ZpitConfig struct {
+	Enabled bool
+	Bin     string
+	Config  string
+	Args    []string
+}
+
 // Config holds the runtime configuration for the zplex daemon.
 type Config struct {
 	Port         int
 	DefaultShell string
 	BufferSize   int
+	Zpit         ZpitConfig
 }
 
-// fileConfig mirrors the TOML file structure with a [daemon] section.
+// fileConfig mirrors the TOML file structure with [daemon] and [zpit] sections.
 type fileConfig struct {
-	Daemon daemonConfig `toml:"daemon"`
+	Daemon daemonConfig   `toml:"daemon"`
+	Zpit   zpitFileConfig `toml:"zpit"`
 }
 
 // daemonConfig maps the fields inside the [daemon] TOML section.
@@ -38,6 +53,16 @@ type daemonConfig struct {
 	Port         int    `toml:"port"`
 	DefaultShell string `toml:"default_shell"`
 	BufferSize   int    `toml:"buffer_size"`
+}
+
+// zpitFileConfig maps the fields inside the [zpit] TOML section.
+// Enabled is a *bool to distinguish "not set" (nil → keep default true)
+// from explicit "enabled = false" (false).
+type zpitFileConfig struct {
+	Enabled *bool    `toml:"enabled"`
+	Bin     string   `toml:"bin"`
+	Config  string   `toml:"config"`
+	Args    []string `toml:"args"`
 }
 
 // Load builds a Config by layering sources in priority order:
@@ -50,6 +75,12 @@ func Load() (*Config, error) {
 		Port:         DefaultPort,
 		DefaultShell: DefaultShell,
 		BufferSize:   DefaultBufferSize,
+		Zpit: ZpitConfig{
+			Enabled: true,
+			Bin:     DefaultZpitBin,
+			Config:  "",
+			Args:    []string{},
+		},
 	}
 
 	// Layer 1: TOML config file.
@@ -67,6 +98,8 @@ func Load() (*Config, error) {
 		slog.Int("port", cfg.Port),
 		slog.String("default_shell", cfg.DefaultShell),
 		slog.Int("buffer_size", cfg.BufferSize),
+		slog.Bool("zpit_enabled", cfg.Zpit.Enabled),
+		slog.String("zpit_bin", cfg.Zpit.Bin),
 	)
 	return cfg, nil
 }
@@ -83,9 +116,16 @@ func applyFileConfig(cfg *Config) error {
 	}
 
 	path := filepath.Join(home, ".zplex", "config.toml")
+	return applyFileConfigFromPath(cfg, path)
+}
 
+// applyFileConfigFromPath reads the TOML config at the given path and applies
+// any values found into cfg. If the file does not exist, it silently returns
+// without error. This helper is separate from applyFileConfig to allow unit tests
+// to supply a temp-file path without touching the user's home directory.
+func applyFileConfigFromPath(cfg *Config, path string) error {
 	var fc fileConfig
-	_, err = toml.DecodeFile(path, &fc)
+	_, err := toml.DecodeFile(path, &fc)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			// No config file — use defaults without logging an error.
@@ -104,6 +144,19 @@ func applyFileConfig(cfg *Config) error {
 	}
 	if fc.Daemon.BufferSize != 0 {
 		cfg.BufferSize = fc.Daemon.BufferSize
+	}
+
+	if fc.Zpit.Enabled != nil {
+		cfg.Zpit.Enabled = *fc.Zpit.Enabled
+	}
+	if fc.Zpit.Bin != "" {
+		cfg.Zpit.Bin = fc.Zpit.Bin
+	}
+	if fc.Zpit.Config != "" {
+		cfg.Zpit.Config = fc.Zpit.Config
+	}
+	if len(fc.Zpit.Args) > 0 {
+		cfg.Zpit.Args = fc.Zpit.Args
 	}
 
 	return nil

--- a/daemon/config/config_test.go
+++ b/daemon/config/config_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// defaultTestConfig returns a Config initialized with the same layer-0 defaults
+// as Load(), so the applyFileConfigFromPath logic is genuinely exercised.
+func defaultTestConfig() *Config {
+	return &Config{
+		Port:         DefaultPort,
+		DefaultShell: DefaultShell,
+		BufferSize:   DefaultBufferSize,
+		Zpit: ZpitConfig{
+			Enabled: true,
+			Bin:     DefaultZpitBin,
+			Config:  "",
+			Args:    []string{},
+		},
+	}
+}
+
+// writeTempConfig writes content to a temporary TOML file and returns its path.
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writeTempConfig: %v", err)
+	}
+	return path
+}
+
+// TestZpitDefaults_NoSection verifies that when no [zpit] section exists in the
+// TOML file, the defaults Enabled==true and Bin=="zpit" are preserved.
+func TestZpitDefaults_NoSection(t *testing.T) {
+	path := writeTempConfig(t, `
+[daemon]
+port = 17732
+`)
+	cfg := defaultTestConfig()
+	if err := applyFileConfigFromPath(cfg, path); err != nil {
+		t.Fatalf("applyFileConfigFromPath: %v", err)
+	}
+
+	if !cfg.Zpit.Enabled {
+		t.Errorf("Zpit.Enabled: got false, want true (missing [zpit] section must preserve default)")
+	}
+	if cfg.Zpit.Bin != "zpit" {
+		t.Errorf("Zpit.Bin: got %q, want %q", cfg.Zpit.Bin, "zpit")
+	}
+}
+
+// TestZpitEnabledFalse verifies that an explicit "enabled = false" in [zpit]
+// sets Enabled to false, even though the bool zero-value is also false.
+func TestZpitEnabledFalse(t *testing.T) {
+	path := writeTempConfig(t, `
+[zpit]
+enabled = false
+`)
+	cfg := defaultTestConfig()
+	if err := applyFileConfigFromPath(cfg, path); err != nil {
+		t.Fatalf("applyFileConfigFromPath: %v", err)
+	}
+
+	if cfg.Zpit.Enabled {
+		t.Errorf("Zpit.Enabled: got true, want false (explicit enabled=false must override default)")
+	}
+}
+
+// TestZpitCustomValues verifies that custom bin, config, and args are parsed
+// verbatim from the [zpit] TOML section.
+func TestZpitCustomValues(t *testing.T) {
+	path := writeTempConfig(t, `
+[zpit]
+bin    = "/usr/local/bin/zpit"
+config = "/home/user/.zpit/config.toml"
+args   = ["--broker-port", "17731", "--verbose"]
+`)
+	cfg := defaultTestConfig()
+	if err := applyFileConfigFromPath(cfg, path); err != nil {
+		t.Fatalf("applyFileConfigFromPath: %v", err)
+	}
+
+	// Enabled must still be true (not set in TOML — nil pointer → keep default).
+	if !cfg.Zpit.Enabled {
+		t.Errorf("Zpit.Enabled: got false, want true (key absent means keep default true)")
+	}
+
+	wantBin := "/usr/local/bin/zpit"
+	if cfg.Zpit.Bin != wantBin {
+		t.Errorf("Zpit.Bin: got %q, want %q", cfg.Zpit.Bin, wantBin)
+	}
+
+	wantConfig := "/home/user/.zpit/config.toml"
+	if cfg.Zpit.Config != wantConfig {
+		t.Errorf("Zpit.Config: got %q, want %q", cfg.Zpit.Config, wantConfig)
+	}
+
+	wantArgs := []string{"--broker-port", "17731", "--verbose"}
+	if len(cfg.Zpit.Args) != len(wantArgs) {
+		t.Fatalf("Zpit.Args length: got %d, want %d", len(cfg.Zpit.Args), len(wantArgs))
+	}
+	for i, want := range wantArgs {
+		if cfg.Zpit.Args[i] != want {
+			t.Errorf("Zpit.Args[%d]: got %q, want %q", i, cfg.Zpit.Args[i], want)
+		}
+	}
+}

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -38,7 +38,17 @@ func main() {
 	}
 
 	// Build the HTTP/WebSocket server wired to the session manager.
-	srv := server.NewServer(mgr, prefsStore)
+	srv := server.NewServer(mgr, prefsStore, cfg.Zpit)
+
+	// Auto-launch the fixed zpit cockpit session when enabled. A failure here
+	// (e.g. zpit binary not on PATH) must not bring down the daemon.
+	if cfg.Zpit.Enabled {
+		if _, err := srv.LaunchZpit(); err != nil {
+			slog.Warn("zpit auto-launch failed", slog.String("error", err.Error()))
+		} else {
+			slog.Info("zpit fixed session auto-launched")
+		}
+	}
 
 	httpServer := &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.Port),

--- a/daemon/server/api.go
+++ b/daemon/server/api.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/zac15987/zplex/daemon/prefs"
@@ -86,9 +87,9 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 type createSessionRequest struct {
 	Shell string   `json:"shell"`
 	Title string   `json:"title"`
-	Args  []string `json:"args,omitempty"` // reserved for future use
-	Cwd   string   `json:"cwd,omitempty"`  // reserved for future use
-	Env   []string `json:"env,omitempty"`  // reserved for future use
+	Args  []string `json:"args,omitempty"`
+	Cwd   string   `json:"cwd,omitempty"`
+	Env   []string `json:"env,omitempty"`
 	Cols  int      `json:"cols"`
 	Rows  int      `json:"rows"`
 }
@@ -129,6 +130,9 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 		Title: req.Title,
 		Cols:  req.Cols,
 		Rows:  req.Rows,
+		Args:  req.Args,
+		Cwd:   req.Cwd,
+		Env:   req.Env,
 	})
 	if err != nil {
 		slog.Error("server.handleCreateSession: failed to create session",
@@ -173,11 +177,31 @@ func (s *Server) handleGetSession(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleDeleteSession kills a session and removes it from the manager.
+// Sessions with Kind=="fixed" are protected and cannot be deleted via this
+// endpoint — they return HTTP 403 to prevent accidental removal.
 func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	slog.Info("server.handleDeleteSession: deleting session",
 		slog.String("session_id", id),
 	)
+
+	sess, err := s.mgr.Get(id)
+	if err != nil {
+		if errors.Is(err, session.ErrSessionNotFound) {
+			writeError(w, http.StatusNotFound, "session not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to get session")
+		return
+	}
+
+	if sess.Info().Kind == "fixed" {
+		slog.Warn("server.handleDeleteSession: refusing to delete fixed session",
+			slog.String("session_id", id),
+		)
+		writeError(w, http.StatusForbidden, "cannot delete fixed session")
+		return
+	}
 
 	if err := s.mgr.Kill(id); err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
@@ -238,6 +262,78 @@ func (s *Server) handlePatchSession(w http.ResponseWriter, r *http.Request) {
 	)
 
 	writeJSON(w, http.StatusOK, sess.Info())
+}
+
+// ---------------------------------------------------------------------------
+// zpit integration
+// ---------------------------------------------------------------------------
+
+// LaunchZpit creates the single fixed zpit session via the session manager.
+// Env is set only when a custom ZPIT_CONFIG path is configured; otherwise the
+// child inherits the daemon's environment. Returns the created session or an
+// error if the zpit binary cannot start.
+func (s *Server) LaunchZpit() (*session.Session, error) {
+	slog.Info("server.LaunchZpit: launching zpit fixed session")
+
+	var env []string
+	if s.zpitCfg.Config != "" {
+		env = append(os.Environ(), "ZPIT_CONFIG="+s.zpitCfg.Config)
+	}
+
+	sess, err := s.mgr.CreateSession(session.CreateOptions{
+		Shell: s.zpitCfg.Bin,
+		Title: "zpit",
+		Kind:  "fixed",
+		Args:  s.zpitCfg.Args,
+		Env:   env,
+	})
+	if err != nil {
+		slog.Error("server.LaunchZpit: failed to launch zpit",
+			slog.String("error", err.Error()),
+		)
+		return nil, err
+	}
+
+	slog.Info("server.LaunchZpit: zpit fixed session launched",
+		slog.String("session_id", sess.ID),
+	)
+	return sess, nil
+}
+
+// handleRestartZpit handles POST /api/zpit/restart. It tears down any existing
+// fixed session and re-launches zpit, returning the new session's ID and WS URL.
+func (s *Server) handleRestartZpit(w http.ResponseWriter, r *http.Request) {
+	slog.Info("server.handleRestartZpit: processing zpit restart request")
+
+	if !s.zpitCfg.Enabled {
+		writeError(w, http.StatusConflict, "zpit is disabled")
+		return
+	}
+
+	if existing, ok := s.mgr.FixedSession(); ok {
+		if err := s.mgr.Kill(existing.ID); err != nil {
+			slog.Warn("server.handleRestartZpit: failed to kill existing fixed session",
+				slog.String("session_id", existing.ID),
+				slog.String("error", err.Error()),
+			)
+			// Non-fatal: continue to launch a new session.
+		}
+	}
+
+	sess, err := s.LaunchZpit()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to launch zpit")
+		return
+	}
+
+	slog.Info("server.handleRestartZpit: zpit restarted",
+		slog.String("session_id", sess.ID),
+	)
+
+	writeJSON(w, http.StatusCreated, createSessionResponse{
+		ID:    sess.ID,
+		WsURL: "/ws/" + sess.ID,
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/daemon/server/api_test.go
+++ b/daemon/server/api_test.go
@@ -10,27 +10,36 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/zac15987/zplex/daemon/config"
 	"github.com/zac15987/zplex/daemon/prefs"
 	"github.com/zac15987/zplex/daemon/session"
 )
 
-// newTestServer creates a Server backed by a real SessionManager for
-// integration testing. The test server and manager are torn down
-// automatically when the test finishes.
-func newTestServer(t *testing.T) (*Server, *httptest.Server) {
+// newTestServerWithZpit creates a Server backed by a real SessionManager for
+// integration testing, using the given ZpitConfig. The test server and manager
+// are torn down automatically when the test finishes.
+func newTestServerWithZpit(t *testing.T, zpitCfg config.ZpitConfig) (*Server, *httptest.Server) {
 	t.Helper()
 	mgr := session.NewSessionManager("pwsh", 102400)
 	prefsStore, err := prefs.NewStoreWithPath(filepath.Join(t.TempDir(), "preferences.json"))
 	if err != nil {
 		t.Fatalf("failed to create prefs store: %v", err)
 	}
-	srv := NewServer(mgr, prefsStore)
+	srv := NewServer(mgr, prefsStore, zpitCfg)
 	ts := httptest.NewServer(srv.Handler())
 	t.Cleanup(func() {
 		ts.Close()
 		mgr.Shutdown()
 	})
 	return srv, ts
+}
+
+// newTestServer creates a Server backed by a real SessionManager for
+// integration testing. The test server and manager are torn down
+// automatically when the test finishes.
+func newTestServer(t *testing.T) (*Server, *httptest.Server) {
+	t.Helper()
+	return newTestServerWithZpit(t, config.ZpitConfig{Enabled: true, Bin: "pwsh"})
 }
 
 // wsURL converts an httptest.Server URL to a WebSocket URL for the given path.
@@ -326,6 +335,130 @@ func TestDeleteSession_NotFound(t *testing.T) {
 
 	if resp.StatusCode != http.StatusNotFound {
 		t.Errorf("expected status 404, got %d", resp.StatusCode)
+	}
+}
+
+// TestDeleteSession_FixedProtected verifies that DELETE on a fixed session
+// returns HTTP 403 with the exact error body and leaves the session intact.
+func TestDeleteSession_FixedProtected(t *testing.T) {
+	srv, ts := newTestServer(t)
+
+	sess, err := srv.LaunchZpit()
+	if err != nil {
+		t.Fatalf("LaunchZpit failed: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/api/sessions/"+sess.ID, nil)
+	if err != nil {
+		t.Fatalf("failed to create DELETE request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE /api/sessions/%s failed: %v", sess.ID, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("expected status 403, got %d", resp.StatusCode)
+	}
+
+	var errResp errorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if errResp.Error != "cannot delete fixed session" {
+		t.Errorf("expected error %q, got %q", "cannot delete fixed session", errResp.Error)
+	}
+
+	// Verify the fixed session is still listed with status "running".
+	getResp, err := http.Get(ts.URL + "/api/sessions")
+	if err != nil {
+		t.Fatalf("GET /api/sessions failed: %v", err)
+	}
+	defer getResp.Body.Close()
+
+	var infos []session.SessionInfo
+	if err := json.NewDecoder(getResp.Body).Decode(&infos); err != nil {
+		t.Fatalf("failed to decode sessions list: %v", err)
+	}
+
+	found := false
+	for _, info := range infos {
+		if info.ID == sess.ID {
+			found = true
+			if info.Status != "running" {
+				t.Errorf("fixed session status: expected %q, got %q", "running", info.Status)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("fixed session %q not found in session list after attempted delete", sess.ID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// zpit restart endpoint
+// ---------------------------------------------------------------------------
+
+// TestRestartZpit_Disabled verifies that POST /api/zpit/restart returns
+// HTTP 409 with the appropriate error body when zpit is disabled.
+func TestRestartZpit_Disabled(t *testing.T) {
+	_, ts := newTestServerWithZpit(t, config.ZpitConfig{Enabled: false})
+
+	resp, err := http.Post(ts.URL+"/api/zpit/restart", "application/json", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("POST /api/zpit/restart failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("expected status 409, got %d", resp.StatusCode)
+	}
+
+	var errResp errorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if errResp.Error != "zpit is disabled" {
+		t.Errorf("expected error %q, got %q", "zpit is disabled", errResp.Error)
+	}
+}
+
+// TestRestartZpit_Success verifies that POST /api/zpit/restart returns
+// HTTP 201 with a new session ID that differs from the previously launched one.
+func TestRestartZpit_Success(t *testing.T) {
+	srv, ts := newTestServer(t)
+
+	oldSess, err := srv.LaunchZpit()
+	if err != nil {
+		t.Fatalf("initial LaunchZpit failed: %v", err)
+	}
+
+	resp, err := http.Post(ts.URL+"/api/zpit/restart", "application/json", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("POST /api/zpit/restart failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	var result createSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode restart response: %v", err)
+	}
+
+	if result.ID == "" {
+		t.Error("expected non-empty session ID in restart response")
+	}
+	if result.ID == oldSess.ID {
+		t.Errorf("expected new session ID to differ from old %q, but got same ID", oldSess.ID)
+	}
+	if !strings.HasPrefix(result.WsURL, "/ws/") {
+		t.Errorf("expected ws_url to start with /ws/, got %q", result.WsURL)
 	}
 }
 

--- a/daemon/server/router.go
+++ b/daemon/server/router.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/zac15987/zplex/daemon/config"
 	"github.com/zac15987/zplex/daemon/prefs"
 	"github.com/zac15987/zplex/daemon/session"
 )
@@ -30,15 +31,16 @@ type Server struct {
 	mgr       *session.SessionManager
 	startTime time.Time
 	version   string
-	layoutMu sync.Mutex
-	layouts  map[string]layoutState // key = workspace ID
-	prefs    *prefs.Store
+	layoutMu  sync.Mutex
+	layouts   map[string]layoutState // key = workspace ID
+	prefs     *prefs.Store
+	zpitCfg   config.ZpitConfig
 }
 
-// NewServer creates a Server wired to the given session manager and
-// preferences store. The returned Server exposes a Handler() method that
-// produces a fully-configured http.Handler (mux + middleware).
-func NewServer(mgr *session.SessionManager, prefsStore *prefs.Store) *Server {
+// NewServer creates a Server wired to the given session manager, preferences
+// store, and zpit configuration. The returned Server exposes a Handler() method
+// that produces a fully-configured http.Handler (mux + middleware).
+func NewServer(mgr *session.SessionManager, prefsStore *prefs.Store, zpitCfg config.ZpitConfig) *Server {
 	slog.Info("server.NewServer: initializing HTTP server")
 	return &Server{
 		mgr:       mgr,
@@ -46,6 +48,7 @@ func NewServer(mgr *session.SessionManager, prefsStore *prefs.Store) *Server {
 		version:   "0.1.0",
 		layouts:   make(map[string]layoutState),
 		prefs:     prefsStore,
+		zpitCfg:   zpitCfg,
 	}
 }
 
@@ -69,6 +72,8 @@ func (s *Server) Handler() http.Handler {
 
 	mux.HandleFunc("GET /api/preferences", s.handleGetPreferences)
 	mux.HandleFunc("PUT /api/preferences", s.handlePutPreferences)
+
+	mux.HandleFunc("POST /api/zpit/restart", s.handleRestartZpit)
 
 	mux.HandleFunc("GET /ws/{session_id}", s.handleWebSocket)
 

--- a/daemon/session/manager.go
+++ b/daemon/session/manager.go
@@ -43,7 +43,7 @@ func (m *SessionManager) Create(title string) (*Session, error) {
 
 	id := "s-" + generateID()
 
-	sess, err := NewSession(id, title, m.shell, m.bufferSize)
+	sess, err := NewSession(id, title, m.shell, nil, "", nil, "", m.bufferSize)
 	if err != nil {
 		slog.Error("manager.Create: failed to create session",
 			slog.String("title", title),
@@ -66,6 +66,10 @@ type CreateOptions struct {
 	Title string
 	Cols  int
 	Rows  int
+	Args  []string
+	Env   []string
+	Cwd   string
+	Kind  string
 }
 
 // CreateSession spawns a new PTY-backed session with the given options.
@@ -77,6 +81,7 @@ func (m *SessionManager) CreateSession(opts CreateOptions) (*Session, error) {
 		slog.String("shell", opts.Shell),
 		slog.Int("cols", opts.Cols),
 		slog.Int("rows", opts.Rows),
+		slog.String("kind", opts.Kind),
 	)
 
 	shell := opts.Shell
@@ -86,7 +91,7 @@ func (m *SessionManager) CreateSession(opts CreateOptions) (*Session, error) {
 
 	id := "s-" + generateID()
 
-	sess, err := NewSession(id, opts.Title, shell, m.bufferSize)
+	sess, err := NewSession(id, opts.Title, shell, opts.Args, opts.Cwd, opts.Env, opts.Kind, m.bufferSize)
 	if err != nil {
 		slog.Error("manager.CreateSession: failed to create session",
 			slog.String("title", opts.Title),
@@ -199,6 +204,27 @@ func (m *SessionManager) Shutdown() {
 	m.sessions = make(map[string]*Session)
 
 	slog.Info("manager.Shutdown: all sessions closed")
+}
+
+// FixedSession returns the single Kind=="fixed" session if one exists.
+// The bool is false when no fixed session is currently registered.
+func (m *SessionManager) FixedSession() (*Session, bool) {
+	slog.Info("manager.FixedSession: looking up fixed session")
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for _, sess := range m.sessions {
+		if sess.Kind == "fixed" {
+			slog.Info("manager.FixedSession: fixed session found",
+				slog.String("session_id", sess.ID),
+			)
+			return sess, true
+		}
+	}
+
+	slog.Info("manager.FixedSession: no fixed session found")
+	return nil, false
 }
 
 // generateID produces a 16-character hex string from 8 random bytes.

--- a/daemon/session/manager_test.go
+++ b/daemon/session/manager_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -110,7 +111,7 @@ func TestRingBuffer_EmptyWrite(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestSessionCreate_PTYIO(t *testing.T) {
-	sess, err := NewSession("test-io", "test IO session", "pwsh", 102400)
+	sess, err := NewSession("test-io", "test IO session", "pwsh", nil, "", nil, "", 102400)
 	if err != nil {
 		t.Fatalf("NewSession failed: %v", err)
 	}
@@ -145,7 +146,7 @@ func TestSessionCreate_PTYIO(t *testing.T) {
 }
 
 func TestSessionInfo(t *testing.T) {
-	sess, err := NewSession("test-info", "info test", "pwsh", 102400)
+	sess, err := NewSession("test-info", "info test", "pwsh", nil, "", nil, "", 102400)
 	if err != nil {
 		t.Fatalf("NewSession failed: %v", err)
 	}
@@ -176,7 +177,7 @@ func TestSessionInfo(t *testing.T) {
 func TestSession_NaturalExit(t *testing.T) {
 	// Test that when the shell exits naturally (via "exit" command),
 	// the session detects it: Status becomes "exited" and Done() closes.
-	sess, err := NewSession("test-natural-exit", "natural exit test", "pwsh", 102400)
+	sess, err := NewSession("test-natural-exit", "natural exit test", "pwsh", nil, "", nil, "", 102400)
 	if err != nil {
 		t.Fatalf("NewSession failed: %v", err)
 	}
@@ -215,7 +216,7 @@ func TestSession_NaturalExit(t *testing.T) {
 func TestSession_CloseSignalsDone(t *testing.T) {
 	// Test that Close() terminates the subprocess, closes the Done
 	// channel, and transitions Status to "exited".
-	sess, err := NewSession("test-close-done", "close done test", "cmd.exe", 102400)
+	sess, err := NewSession("test-close-done", "close done test", "cmd.exe", nil, "", nil, "", 102400)
 	if err != nil {
 		t.Fatalf("NewSession failed: %v", err)
 	}
@@ -377,5 +378,89 @@ func TestManager_Shutdown(t *testing.T) {
 	infos = mgr.List()
 	if len(infos) != 0 {
 		t.Errorf("expected 0 sessions after shutdown, got %d", len(infos))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateSession with Cwd, Args, Kind — AC-3 coverage.
+// ---------------------------------------------------------------------------
+
+func TestCreateSession_WithCwdArgsKind(t *testing.T) {
+	mgr := NewSessionManager("pwsh", 102400)
+	defer mgr.Shutdown()
+
+	// Resolve the full path to pwsh so that go-pty on Windows does not try to
+	// look it up relative to Cwd (Windows CreateProcess quirk replicated by the
+	// go-pty library when Dir is set).
+	pwshPath, err := exec.LookPath("pwsh")
+	if err != nil {
+		t.Skipf("pwsh not found in PATH, skipping: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+
+	sess, err := mgr.CreateSession(CreateOptions{
+		Shell: pwshPath,
+		Title: "fixed-test",
+		Cwd:   tmpDir,
+		Args:  []string{"-NoLogo"},
+		Kind:  "fixed",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	info := sess.Info()
+	if info.PID <= 0 {
+		t.Errorf("expected PID > 0, got %d", info.PID)
+	}
+	if info.Kind != "fixed" {
+		t.Errorf("expected Kind %q, got %q", "fixed", info.Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FixedSession helper — AC-5 coverage.
+// ---------------------------------------------------------------------------
+
+func TestFixedSession_Helper(t *testing.T) {
+	// A fresh manager with no sessions should return ok==false.
+	emptyMgr := NewSessionManager("pwsh", 102400)
+	defer emptyMgr.Shutdown()
+
+	if _, ok := emptyMgr.FixedSession(); ok {
+		t.Error("expected FixedSession to return ok==false on empty manager")
+	}
+
+	// A manager with one normal session and one fixed session.
+	mgr := NewSessionManager("pwsh", 102400)
+	defer mgr.Shutdown()
+
+	// Create a normal (non-fixed) session.
+	_, err := mgr.CreateSession(CreateOptions{
+		Shell: "pwsh",
+		Title: "normal-session",
+		Kind:  "",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession (normal) failed: %v", err)
+	}
+
+	// Create a fixed session.
+	fixedSess, err := mgr.CreateSession(CreateOptions{
+		Shell: "pwsh",
+		Title: "fixed-session",
+		Kind:  "fixed",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession (fixed) failed: %v", err)
+	}
+
+	got, ok := mgr.FixedSession()
+	if !ok {
+		t.Fatal("expected FixedSession to return ok==true")
+	}
+	if got.ID != fixedSess.ID {
+		t.Errorf("expected FixedSession ID %q, got %q", fixedSess.ID, got.ID)
 	}
 }

--- a/daemon/session/session.go
+++ b/daemon/session/session.go
@@ -20,6 +20,7 @@ type SessionInfo struct {
 	CreatedAt time.Time `json:"created_at"`
 	PID       int       `json:"pid"`
 	ExitCode  int       `json:"exit_code"`
+	Kind      string    `json:"kind"`
 }
 
 // Session represents a single PTY-backed terminal session.
@@ -32,6 +33,7 @@ type Session struct {
 	CreatedAt time.Time
 	PID       int
 	ExitCode  int
+	Kind      string // "" = normal/agent session; "fixed" = zpit fixed panel
 
 	pty      pty.Pty     // PTY handle (ConPTY on Windows, /dev/ptmx on Unix)
 	cmd      *pty.Cmd    // the running subprocess
@@ -52,12 +54,16 @@ const readBufSize = 8192
 
 // NewSession spawns a new PTY-backed shell session.
 // The caller provides a unique id, a human-readable title, the shell executable
-// to run, and the ring-buffer capacity in bytes.
-func NewSession(id, title, shell string, bufferSize int) (*Session, error) {
+// to run, optional extra args, an optional working directory (cwd), optional
+// environment variables (env), a kind tag ("" for normal/agent, "fixed" for the
+// zpit fixed panel), and the ring-buffer capacity in bytes.
+func NewSession(id, title, shell string, args []string, cwd string, env []string, kind string, bufferSize int) (*Session, error) {
 	slog.Info("session.NewSession: creating session",
 		slog.String("session_id", id),
 		slog.String("title", title),
 		slog.String("shell", shell),
+		slog.String("kind", kind),
+		slog.Int("args_count", len(args)),
 		slog.Int("buffer_size", bufferSize),
 	)
 
@@ -70,7 +76,13 @@ func NewSession(id, title, shell string, bufferSize int) (*Session, error) {
 		return nil, err
 	}
 
-	cmd := ptmx.Command(shell)
+	cmd := ptmx.Command(shell, args...)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	if env != nil {
+		cmd.Env = env
+	}
 	if err := cmd.Start(); err != nil {
 		slog.Error("session.NewSession: failed to start command",
 			slog.String("session_id", id),
@@ -89,6 +101,7 @@ func NewSession(id, title, shell string, bufferSize int) (*Session, error) {
 		Status:    "running",
 		CreatedAt: time.Now(),
 		PID:       pid,
+		Kind:      kind,
 		pty:       ptmx,
 		cmd:       cmd,
 		ringBuf:   newRingBuffer(bufferSize),
@@ -295,6 +308,7 @@ func (s *Session) Info() SessionInfo {
 		CreatedAt: s.CreatedAt,
 		PID:       s.PID,
 		ExitCode:  s.ExitCode,
+		Kind:      s.Kind,
 	}
 }
 

--- a/docs/zplex-project-plan.md
+++ b/docs/zplex-project-plan.md
@@ -206,9 +206,9 @@ zplex/
 
 ## 5. Milestones
 
-> **Progress (2026-04-12):** M1 and M2 complete — all six issues (#1, #2, #5, #7, #8, #11) are merged and closed. The Go daemon is functional (session CRUD, PTY/ConPTY, REST API, WebSocket I/O relay, ring buffer replay, per-workspace layout persistence) and the Electron app has multi-panel auto-tiled CSS Grid layout, draggable gutter resize, keyboard navigation, close confirmation dialogs, layout restore reconciliation, and workspace tabs with dispose/recreate switching. M3 is next.
+> **Progress (2026-06-09):** M1, M2, and M3 complete. M3 (issue #13) delivered the always-visible zpit cockpit: the daemon auto-launches a fixed `kind="fixed"` session on startup (configurable via `[zpit]`), protects it from deletion (DELETE → 403) with a `POST /api/zpit/restart` endpoint, and the frontend mounts it in a persistent `#main-split` fixed panel (draggable splitter, exited+Restart overlay, graceful fallback when zpit is absent). M4 (zpit launcher integration) is next.
 >
-> Note: The original plan's single "Go daemon" issue was split into #1 (session+PTY) and #2 (HTTP+WebSocket) during implementation. The original M2 "multi-panel layout" and "panel resize + keyboard navigation" items were combined into a single issue #7. Remaining issues use TBD as they haven't been filed on GitHub yet.
+> Note: The original plan's single "Go daemon" issue was split into #1 (session+PTY) and #2 (HTTP+WebSocket) during implementation. The original M2 "multi-panel layout" and "panel resize + keyboard navigation" items were combined into a single issue #7. M3's two planned items were combined into a single issue #13.
 
 ### M1: Skeleton — single terminal works end-to-end
 
@@ -253,8 +253,8 @@ zplex/
 
 | Issue | Title | Description | Status | Depends |
 |---|---|---|---|---|
-| TBD | Daemon: auto-create zpit session on startup | Read zpit config location (env `ZPIT_CONFIG` or `~/.zpit/config.toml`). On daemon start, create a special session running `zpit` binary. Mark as "fixed" (cannot be killed from UI) | Planned | M2 |
-| TBD | Frontend: fixed panel vs dynamic panels | Left panel always shows zpit session (not closable, distinct border/header). Right area is dynamic panel grid for agents. Layout: `[fixed 35%] [dynamic 65%]` adjustable | Planned | zpit session |
+| #13 | Daemon: auto-create zpit session on startup | Read zpit config location (env `ZPIT_CONFIG` or `~/.zpit/config.toml`). On daemon start, create a special session running `zpit` binary. Mark as "fixed" (cannot be killed from UI) | ✅ Done | M2 |
+| #13 | Frontend: fixed panel vs dynamic panels | Left panel always shows zpit session (not closable, distinct border/header). Right area is dynamic panel grid for agents. Layout: `[fixed 35%] [dynamic 65%]` adjustable | ✅ Done | zpit session |
 
 **Demo scenario after M3:**
 1. Open zplex → left panel shows zpit TUI, right area is empty


### PR DESCRIPTION
## Summary

Implements **M3 — zpit fixed cockpit panel** (issue #13): the zplex daemon auto-launches zpit in an always-visible "cockpit" panel on the left, with the existing dynamic agent grid on the right.

Closes #13.

## Approach (decisions recorded)

- **Single combined issue** (daemon + frontend), per the issue spec.
- **Frontend layout — Option A (outer split container).** The terminal area is wrapped in `#main-split = [#fixed-panel-area][#v-splitter][#grid-container]`. The zpit terminal mounts into the fixed area and **never** enters `PanelGrid`, so the auto-tile algorithm, gutter logic, navigation, layout persistence, and close protection in `layout.ts` are entirely untouched (Option B — reserving index 0 inside PanelGrid — was rejected for high regression risk).
- **Global cockpit.** The `FixedPanel` is created once at init and survives workspace switch/close (never disposed). On process exit it shows a `zpit exited` overlay with a manual **Restart** button (no auto-restart, to avoid a crash loop).
- **Daemon owns launch.** `Server.LaunchZpit()` is the single launch path used by both startup (`main.go`) and the restart endpoint. The fixed session is spawned with `Shell=[zpit].bin` (default `zpit`, PATH-resolved), `Args=[zpit].args`, and `Env=os.Environ()+ZPIT_CONFIG` only when `[zpit].config` is non-empty.
- **Graceful fallback.** When zpit is disabled or its binary is not found, the daemon creates no fixed session and the frontend falls back to the pure M2 dynamic grid (`#main-split.no-fixed`).
- **Split ratio is pure UI state** in `localStorage` (`zplex:fixedPanelRatio`, default 0.35), not daemon preferences.

## Changes

**Daemon (Go)**
- `config`: new `[zpit]` section → `ZpitConfig {Enabled, Bin, Config, Args}`; `enabled` decoded via `*bool` so a missing key defaults to `true`.
- `session`: `Kind` field on `Session`/`SessionInfo` (`json:"kind"`); `NewSession` now takes `args/cwd/env/kind` (`ptmx.Command(shell, args...)`, `cmd.Dir`, `cmd.Env`); `CreateOptions` gains `Args/Env/Cwd/Kind`; `FixedSession()` helper.
- `server`: `POST /api/sessions` forwards `args/cwd/env`; `DELETE /api/sessions/{id}` returns **403** `{"error":"cannot delete fixed session"}` for `kind=="fixed"`; `Server.LaunchZpit()`; `POST /api/zpit/restart` (409 disabled / 201 success / 500 launch-fail); `NewServer` takes the zpit config.
- `main.go`: auto-launch zpit once on startup when enabled; launch failure logs `slog.Warn("zpit auto-launch failed")` and the daemon keeps running.

**Frontend (TypeScript)**
- `index.html`: `#main-split` wrapper (`no-fixed` by default).
- `types.ts`: `SessionInfo.kind`; `FIXED_PANEL_RATIO_KEY` + `DEFAULT_FIXED_PANEL_RATIO`.
- `terminal.ts`: `onExit(cb)` fired on the WS `"exit"` message.
- `fixedpanel.ts` (new): `FixedPanel` — mount, draggable `#v-splitter` with 200px clamp + localStorage persistence, exited/Restart overlay, focus.
- `app.ts`: mounts the fixed session, filters `kind==="fixed"` out of all grid reconciliation (init/switch/close), skips the auto-create "Terminal 1" when the cockpit is present, cross-area `Ctrl+Shift+Left/Right` navigation, and never disposes the FixedPanel.
- `styles.css`: split/splitter layout, `.no-fixed` fallback, teal `#4ec9b0` header accent on the fixed panel, exited overlay.

**Docs**
- `CLAUDE.md`: fixed-panel architecture, `[zpit]` config keys, REST API (`POST /api/zpit/restart`, DELETE 403), cross-panel shortcuts, `kind` field.
- `docs/zplex-project-plan.md`: M3 marked complete (#13), progress note updated.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` — all pass (new tests: config `[zpit]` parsing incl. enabled-default-true; session CreateOptions cwd/args/kind + FixedSession helper; server DELETE 403/204 + restart 409/201).
- `npx tsc --noEmit` — clean (TypeScript strict, no `any`).

## Notes

- Built via 15 decomposed tasks; one follow-up fix removed a redundant `fit()` call in `fixedpanel.ts` that triggered a TS control-flow `never`-narrowing error (the wrapper is fitted by `TerminalWrapper.mount()` + its ResizeObserver).
- Committed Go files use CRLF line endings, consistent with the existing repo convention (`core.autocrlf=true`; pre-existing files like `ws.go` are also CRLF in git). `gofmt` content is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
