### PR TITLE
[15] M4: zpit deep integration — session metadata, SSE panel sync, permission focus nav

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,7 @@ Key behaviors:
 | `Ctrl+Shift+Arrow` | Move focus to adjacent panel (Up/Down/Left/Right); `Ctrl+Shift+Left` from the leftmost grid panel crosses into the zpit fixed panel, and `Ctrl+Shift+Right` from the zpit fixed panel crosses back to the leftmost grid panel |
 | `Ctrl+Shift+PageUp` | Switch to previous workspace (wraps around) |
 | `Ctrl+Shift+PageDown` | Switch to next workspace (wraps around) |
+| `Ctrl+Shift+J` | Jump focus to next agent panel waiting for permission |
 | `Shift+Click [×]` | Force close dialog (override saved preference) |
 
 ### Daemon REST API
@@ -134,13 +135,13 @@ Key behaviors:
 | Method | Path | Purpose |
 |--------|------|---------|
 | GET | `/api/health` | Health check + version |
-| GET/POST | `/api/sessions` | List / create sessions |
-| GET/DELETE/PATCH | `/api/sessions/{id}` | Get / kill / update session; DELETE returns HTTP 403 for the fixed (`kind=="fixed"`) session — it cannot be killed from the UI |
+| GET/POST | `/api/sessions` | List / create sessions; create and list carry agent metadata fields `source`, `project_id`, `issue_id`, `role`, `agent_state` (all optional on create) |
+| GET/DELETE/PATCH | `/api/sessions/{id}` | Get / kill / update session; DELETE returns HTTP 403 for the fixed (`kind=="fixed"`) session — it cannot be killed from the UI; PATCH can update `agent_state` (validated against `"" \| "active" \| "waiting" \| "done"`, invalid value → HTTP 400) |
 | GET/PUT | `/api/layout` | Get / save panel layout (per workspace) |
 | GET | `/api/workspaces` | List workspace IDs with layout data |
 | DELETE | `/api/workspaces/{id}` | Delete workspace layout data |
 | GET/PUT | `/api/preferences` | Get / save app-managed user preferences (close behavior), persisted to `~/.zplex/preferences.json` |
-| GET | `/api/events` | SSE stream for real-time updates |
+| GET | `/api/events` | SSE stream for real-time session updates: emits `session.created`, `session.closed`, `session.updated` events, each carrying the affected session's `SessionInfo` as JSON |
 | POST | `/api/zpit/restart` | Kill (if running) and relaunch the fixed zpit session |
 
 ### WebSocket Protocol (`/ws/{session_id}`)
@@ -151,6 +152,17 @@ Key behaviors:
 ### SessionInfo `kind` field
 
 `SessionInfo` (and `Session`) carry a `kind` field in all `GET /api/sessions` and `GET /api/sessions/{id}` responses: `""` for normal/agent sessions, `"fixed"` for the zpit cockpit session.
+
+### SessionInfo agent metadata fields
+
+`SessionInfo` (and `Session`) also carry agent-integration metadata, returned in all `GET /api/sessions` and `GET /api/sessions/{id}` responses and accepted (all optional) by `POST /api/sessions`:
+
+- `source` — origin of the session (e.g. `"zpit"` when spawned by the zpit loop engine); `""` for manually-created terminals.
+- `project_id`, `issue_id` — the zpit project / issue the agent is working on.
+- `role` — the agent's role (e.g. `"coder"`, `"reviewer"`).
+- `agent_state` — the agent's loop state, decoupled from the PTY `status` field. One of `"" | "active" | "waiting" | "done"`. Drives the panel header status indicator (green = active, amber = waiting for permission, grey = done). Mutable via `PATCH /api/sessions/{id}`; any other value is rejected with HTTP 400.
+
+These fields back the M4 "agent panels auto-appear in zplex" integration: when zpit's loop engine spawns a Claude Code agent it POSTs a session with this metadata, the daemon emits a `session.created` SSE event, and the frontend auto-mounts a panel.
 
 ## Tech Stack Constraints
 

--- a/app/src/app.ts
+++ b/app/src/app.ts
@@ -448,6 +448,43 @@ async function closePanelFlow(sessionId: string, forceDialog: boolean): Promise<
 }
 
 // ---------------------------------------------------------------------------
+// Session-mounted guard and closed-panel removal
+// ---------------------------------------------------------------------------
+
+/** Return true if the session is mounted in any workspace's registry. */
+function isSessionMountedAnywhere(sessionId: string): boolean {
+  for (const [, registry] of workspaces) {
+    if (registry.has(sessionId)) return true;
+  }
+  return false;
+}
+
+/**
+ * Remove a panel that the daemon has already closed. Disposes the terminal
+ * and removes the panel from the grid WITHOUT issuing DELETE /api/sessions
+ * (the session is already gone). Searches all workspace registries.
+ */
+function removeClosedPanel(sessionId: string): void {
+  let found = false;
+  for (const [, registry] of workspaces) {
+    const wrapper = registry.get(sessionId);
+    if (wrapper) {
+      wrapper.dispose();
+      registry.delete(sessionId);
+      found = true;
+      break;
+    }
+  }
+  if (!found) {
+    console.warn("[app] session.closed: panel not mounted, ignoring:", sessionId);
+    return;
+  }
+  panelGrid?.removePanel(sessionId);
+  refitAllTerminals();
+  console.warn("[app] session.closed: removed panel:", sessionId);
+}
+
+// ---------------------------------------------------------------------------
 // Focus navigation
 // ---------------------------------------------------------------------------
 
@@ -500,6 +537,100 @@ function moveFocus(direction: "up" | "down" | "left" | "right"): void {
   const adjacentId = panelGrid.getAdjacentPanelId(currentId, direction);
   if (!adjacentId) return;
   focusGridPanel(adjacentId);
+}
+
+// ---------------------------------------------------------------------------
+// Waiting-panel jump (Ctrl+Shift+J)
+// ---------------------------------------------------------------------------
+
+/**
+ * Move focus to the next panel whose agentState === "waiting", in grid order
+ * (PanelGrid.getPanelIds()), wrapping around. If the currently focused panel
+ * is waiting, focus advances to the NEXT waiting panel. No-op (warn) if none.
+ */
+function jumpToNextWaitingPanel(): void {
+  if (!panelGrid) return;
+  const ids = panelGrid.getPanelIds();
+  if (ids.length === 0) {
+    console.warn("[app] Ctrl+Shift+J: no panels");
+    return;
+  }
+  const focusedId = panelGrid.getFocusedPanelId();
+  const startIdx = focusedId ? ids.indexOf(focusedId) : -1;
+  // Scan the ids in order starting AFTER the focused panel, wrapping around.
+  for (let offset = 1; offset <= ids.length; offset++) {
+    const idx = (startIdx + offset) % ids.length;
+    const id = ids[idx];
+    if (panelGrid.getPanelInfo(id)?.agentState === "waiting") {
+      focusGridPanel(id);
+      console.warn("[app] Ctrl+Shift+J: jumped to waiting panel:", id);
+      return;
+    }
+  }
+  console.warn("[app] Ctrl+Shift+J: no panel waiting for permission");
+}
+
+// ---------------------------------------------------------------------------
+// SSE event source
+// ---------------------------------------------------------------------------
+
+/**
+ * Open the SSE stream to the daemon and react to session lifecycle events:
+ *   - session.created: auto-mount a panel for a non-fixed session not already
+ *     mounted (the daemon-driven "agent auto-appears" behavior).
+ *   - session.updated: recolor the panel's agent-state indicator.
+ *   - session.closed: remove the panel if mounted (no DELETE — already gone).
+ */
+function initEventSource(): void {
+  const port = getDaemonPort();
+  const source = new EventSource(`http://localhost:${port}/api/events`);
+
+  source.addEventListener("session.created", (e: MessageEvent) => {
+    let info: SessionInfo;
+    try {
+      info = JSON.parse(e.data) as SessionInfo;
+    } catch (err: unknown) {
+      console.error("[app] session.created: bad payload:", err);
+      return;
+    }
+    // Skip the fixed zpit cockpit session (it has its own panel) and any
+    // session already mounted (e.g. one the frontend itself POSTed).
+    if (info.kind === "fixed") return;
+    if (isSessionMountedAnywhere(info.id)) return;
+    console.warn("[app] session.created: auto-mounting", info.id);
+    mountSessionToGrid(info.id, info.title);
+    // Reflect any initial agent_state on the freshly mounted panel.
+    if (info.agent_state) {
+      panelGrid?.setAgentState(info.id, info.agent_state);
+    }
+  });
+
+  source.addEventListener("session.updated", (e: MessageEvent) => {
+    let info: SessionInfo;
+    try {
+      info = JSON.parse(e.data) as SessionInfo;
+    } catch (err: unknown) {
+      console.error("[app] session.updated: bad payload:", err);
+      return;
+    }
+    panelGrid?.setAgentState(info.id, info.agent_state);
+  });
+
+  source.addEventListener("session.closed", (e: MessageEvent) => {
+    let info: SessionInfo;
+    try {
+      info = JSON.parse(e.data) as SessionInfo;
+    } catch (err: unknown) {
+      console.error("[app] session.closed: bad payload:", err);
+      return;
+    }
+    removeClosedPanel(info.id);
+  });
+
+  source.onerror = (): void => {
+    // EventSource auto-reconnects; log once at warn level.
+    console.warn("[app] EventSource error (will auto-reconnect)");
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -825,6 +956,14 @@ async function init(): Promise<void> {
         moveFocus("right");
         break;
       }
+
+      // Ctrl+Shift+J: Jump focus to next panel waiting for permission (AC-11)
+      case "J":
+      case "j": {
+        e.preventDefault();
+        jumpToNextWaitingPanel();
+        break;
+      }
     }
   });
 
@@ -976,6 +1115,11 @@ async function init(): Promise<void> {
   // Persist the final post-reconciliation layout state (with correct grid
   // template — either restored custom values or auto-tiled) in a single save.
   saveLayout();
+
+  // Open SSE stream after all locally-created/restored panels are registered
+  // so the dedup guard works for sessions that already existed before the
+  // stream opened.
+  initEventSource();
 
   console.warn("[app] init exit");
 }

--- a/app/src/layout.ts
+++ b/app/src/layout.ts
@@ -101,9 +101,13 @@ export class PanelGrid {
     const element = document.createElement("div");
     element.classList.add("panel");
     element.dataset.sessionId = sessionId;
+    element.dataset.agentState = "";
 
     const headerElement = document.createElement("div");
     headerElement.classList.add("panel-header");
+
+    const statusIndicator = document.createElement("span");
+    statusIndicator.classList.add("panel-status");
 
     const titleSpan = document.createElement("span");
     titleSpan.classList.add("panel-title");
@@ -113,6 +117,7 @@ export class PanelGrid {
     closeBtn.classList.add("panel-close-btn");
     closeBtn.textContent = "\u00d7"; // multiplication sign (x)
 
+    headerElement.appendChild(statusIndicator);
     headerElement.appendChild(titleSpan);
     headerElement.appendChild(closeBtn);
 
@@ -129,6 +134,7 @@ export class PanelGrid {
       element,
       headerElement,
       contentElement,
+      agentState: "",
     };
 
     this.panelOrder.push(sessionId);
@@ -236,6 +242,21 @@ export class PanelGrid {
   /** Look up a panel by session ID. */
   getPanelInfo(sessionId: string): PanelInfo | undefined {
     return this.panelMap.get(sessionId);
+  }
+
+  /**
+   * Set the agent loop state for a panel. Updates the panel root's
+   * data-agent-state attribute (drives the header status indicator color
+   * and the waiting-pulse animation via CSS) and stores it on the PanelInfo.
+   */
+  setAgentState(sessionId: string, state: string): void {
+    const panel = this.panelMap.get(sessionId);
+    if (!panel) {
+      console.warn("[layout] setAgentState: panel not found:", sessionId);
+      return;
+    }
+    panel.agentState = state;
+    panel.element.dataset.agentState = state;
   }
 
   /** Return the current number of panels. */

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -9,6 +9,9 @@
   --gutter-size: 4px;
   --gutter-color: #333;
   --gutter-hover-color: #007acc;
+  --agent-active: #3fb950;
+  --agent-waiting: #d29922;
+  --agent-done: #6e7681;
 }
 
 * {
@@ -255,6 +258,40 @@ html, body {
 
 .panel.focused {
   border-color: var(--panel-focus-border-color);
+}
+
+/* Agent state: status indicator dot in panel header */
+
+.panel-status {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-right: 6px;
+}
+
+.panel[data-agent-state="active"] .panel-status {
+  background-color: var(--agent-active);
+}
+
+.panel[data-agent-state="waiting"] .panel-status {
+  background-color: var(--agent-waiting);
+}
+
+.panel[data-agent-state="done"] .panel-status {
+  background-color: var(--agent-done);
+}
+
+/* Agent waiting: pulsing border animation */
+
+@keyframes agent-waiting-pulse {
+  0%   { border-color: var(--panel-border-color); }
+  50%  { border-color: var(--agent-waiting); }
+  100% { border-color: var(--panel-border-color); }
+}
+
+.panel[data-agent-state="waiting"] {
+  animation: agent-waiting-pulse 1.5s ease-in-out infinite;
 }
 
 /* --- Panel Header --- */

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -20,7 +20,15 @@ export interface SessionInfo {
   created_at: string; // ISO 8601 timestamp
   pid: number;
   exit_code: number;
+  source: string;
+  project_id: string;
+  issue_id: string;
+  role: string;
+  agent_state: string; // "" | "active" | "waiting" | "done" (see AgentState)
 }
+
+/** Agent loop state for a session panel — decoupled from PTY status. */
+export type AgentState = "" | "active" | "waiting" | "done";
 
 /** Request body for POST /api/sessions (server/api.go createSessionRequest). */
 export interface CreateSessionRequest {
@@ -135,6 +143,8 @@ export interface PanelInfo {
   headerElement: HTMLElement;
   /** The terminal content area element. */
   contentElement: HTMLElement;
+  /** Current agent loop state ("" | "active" | "waiting" | "done"); drives the header status indicator. */
+  agentState: string;
 }
 
 /** Computed grid layout dimensions. */
@@ -205,6 +215,19 @@ export interface WorkspaceInfo {
 
 /** Response from GET /api/workspaces — list of workspace IDs with layout data. */
 export type WorkspaceListResponse = string[];
+
+// ---------------------------------------------------------------------------
+// SSE event types (daemon/server/events.go)
+// ---------------------------------------------------------------------------
+
+/** Named SSE event types emitted by the daemon GET /api/events stream. */
+export type ServerEventType = "session.created" | "session.updated" | "session.closed";
+
+/**
+ * Payload of a daemon SSE event. The EventSource `data` field is the
+ * JSON-marshalled SessionInfo for the affected session.
+ */
+export type ServerEventPayload = SessionInfo;
 
 // Ensure this file is treated as a module (required when using `declare global`).
 export {};

--- a/daemon/server/api.go
+++ b/daemon/server/api.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -11,6 +12,13 @@ import (
 	"github.com/zac15987/zplex/daemon/prefs"
 	"github.com/zac15987/zplex/daemon/session"
 )
+
+// validAgentStates is the exact set of accepted agent_state values.
+// Empty string is valid and means "no agent loop state".
+var validAgentStates = map[string]bool{"": true, "active": true, "waiting": true, "done": true}
+
+// isValidAgentState reports whether s is an accepted agent_state value.
+func isValidAgentState(s string) bool { return validAgentStates[s] }
 
 // ---------------------------------------------------------------------------
 // Layout state types
@@ -85,13 +93,18 @@ func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
 
 // createSessionRequest is the JSON body accepted by POST /api/sessions.
 type createSessionRequest struct {
-	Shell string   `json:"shell"`
-	Title string   `json:"title"`
-	Args  []string `json:"args,omitempty"`
-	Cwd   string   `json:"cwd,omitempty"`
-	Env   []string `json:"env,omitempty"`
-	Cols  int      `json:"cols"`
-	Rows  int      `json:"rows"`
+	Shell      string   `json:"shell"`
+	Title      string   `json:"title"`
+	Args       []string `json:"args,omitempty"`
+	Cwd        string   `json:"cwd,omitempty"`
+	Env        []string `json:"env,omitempty"`
+	Cols       int      `json:"cols"`
+	Rows       int      `json:"rows"`
+	Source     string   `json:"source,omitempty"`
+	ProjectID  string   `json:"project_id,omitempty"`
+	IssueID    string   `json:"issue_id,omitempty"`
+	Role       string   `json:"role,omitempty"`
+	AgentState string   `json:"agent_state,omitempty"`
 }
 
 // createSessionResponse is the JSON payload returned by POST /api/sessions.
@@ -125,14 +138,27 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !isValidAgentState(req.AgentState) {
+		slog.Warn("server.handleCreateSession: invalid agent_state",
+			slog.String("agent_state", req.AgentState),
+		)
+		writeError(w, http.StatusBadRequest, "invalid agent_state")
+		return
+	}
+
 	sess, err := s.mgr.CreateSession(session.CreateOptions{
-		Shell: req.Shell,
-		Title: req.Title,
-		Cols:  req.Cols,
-		Rows:  req.Rows,
-		Args:  req.Args,
-		Cwd:   req.Cwd,
-		Env:   req.Env,
+		Shell:      req.Shell,
+		Title:      req.Title,
+		Cols:       req.Cols,
+		Rows:       req.Rows,
+		Args:       req.Args,
+		Cwd:        req.Cwd,
+		Env:        req.Env,
+		Source:     req.Source,
+		ProjectID:  req.ProjectID,
+		IssueID:    req.IssueID,
+		Role:       req.Role,
+		AgentState: req.AgentState,
 	})
 	if err != nil {
 		slog.Error("server.handleCreateSession: failed to create session",
@@ -145,6 +171,9 @@ func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 	slog.Info("server.handleCreateSession: session created",
 		slog.String("session_id", sess.ID),
 	)
+
+	s.hub.Broadcast(Event{Type: "session.created", Session: sess.Info()})
+	s.watchSessionExit(sess)
 
 	writeJSON(w, http.StatusCreated, createSessionResponse{
 		ID:    sess.ID,
@@ -220,13 +249,18 @@ func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
 		slog.String("session_id", id),
 	)
 
+	s.hub.Broadcast(Event{Type: "session.closed", Session: sess.Info()})
+
 	w.WriteHeader(http.StatusNoContent)
 }
 
 // patchSessionRequest is the JSON body accepted by PATCH /api/sessions/{id}.
+// Identity fields (source, project_id, issue_id, role) are intentionally
+// absent — they are immutable after creation.
 type patchSessionRequest struct {
-	Title  string `json:"title"`
-	Status string `json:"status"`
+	Title      string `json:"title"`
+	Status     string `json:"status"`
+	AgentState string `json:"agent_state"`
 }
 
 // handlePatchSession updates mutable metadata on an existing session.
@@ -255,11 +289,21 @@ func (s *Server) handlePatchSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sess.UpdateMeta(req.Title, req.Status)
+	if !isValidAgentState(req.AgentState) {
+		slog.Warn("server.handlePatchSession: invalid agent_state",
+			slog.String("agent_state", req.AgentState),
+		)
+		writeError(w, http.StatusBadRequest, "invalid agent_state")
+		return
+	}
+
+	sess.UpdateMeta(req.Title, req.Status, req.AgentState)
 
 	slog.Info("server.handlePatchSession: session updated",
 		slog.String("session_id", id),
 	)
+
+	s.hub.Broadcast(Event{Type: "session.updated", Session: sess.Info()})
 
 	writeJSON(w, http.StatusOK, sess.Info())
 }
@@ -297,6 +341,10 @@ func (s *Server) LaunchZpit() (*session.Session, error) {
 	slog.Info("server.LaunchZpit: zpit fixed session launched",
 		slog.String("session_id", sess.ID),
 	)
+
+	s.hub.Broadcast(Event{Type: "session.created", Session: sess.Info()})
+	s.watchSessionExit(sess)
+
 	return sess, nil
 }
 
@@ -334,6 +382,75 @@ func (s *Server) handleRestartZpit(w http.ResponseWriter, r *http.Request) {
 		ID:    sess.ID,
 		WsURL: "/ws/" + sess.ID,
 	})
+}
+
+// watchSessionExit starts a goroutine that emits a session.closed event when
+// the given session's process exits naturally (its Done() channel closes).
+// Emission lives at the server-handler layer so the session package stays
+// decoupled from the event Hub.
+func (s *Server) watchSessionExit(sess *session.Session) {
+	go func() {
+		<-sess.Done()
+		slog.Info("server.watchSessionExit: session exited, broadcasting closed",
+			slog.String("session_id", sess.ID))
+		s.hub.Broadcast(Event{Type: "session.closed", Session: sess.Info()})
+	}()
+}
+
+// handleEvents serves the Server-Sent Events stream. Clients subscribe to
+// real-time session lifecycle events (session.created/closed/updated).
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	slog.Info("server.handleEvents: client connecting")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		slog.Error("server.handleEvents: ResponseWriter does not support flushing")
+		writeError(w, http.StatusInternalServerError, "streaming unsupported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	ch := s.hub.Subscribe()
+	defer s.hub.Unsubscribe(ch)
+
+	ticker := time.NewTicker(HeartbeatInterval)
+	defer ticker.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("server.handleEvents: client disconnected")
+			return
+		case ev, ok := <-ch:
+			if !ok {
+				return
+			}
+			data, err := json.Marshal(ev.Session)
+			if err != nil {
+				slog.Error("server.handleEvents: marshal failed", slog.String("error", err.Error()))
+				continue
+			}
+			// SSE frame: event: <type>\ndata: <json>\n\n
+			if _, err := fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, data); err != nil {
+				slog.Warn("server.handleEvents: write failed", slog.String("error", err.Error()))
+				return
+			}
+			flusher.Flush()
+		case <-ticker.C:
+			// Heartbeat comment keeps the connection alive.
+			if _, err := fmt.Fprint(w, ": heartbeat\n\n"); err != nil {
+				slog.Warn("server.handleEvents: heartbeat write failed", slog.String("error", err.Error()))
+				return
+			}
+			flusher.Flush()
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/daemon/server/api_test.go
+++ b/daemon/server/api_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -708,5 +710,286 @@ func TestPreferences_PutInvalidValue(t *testing.T) {
 
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected status 400 for invalid value, got %d", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Session metadata round-trip (AC-2)
+// ---------------------------------------------------------------------------
+
+// TestCreateSession_MetadataRoundTrip verifies that all five identity metadata
+// fields (source, project_id, issue_id, role, agent_state) survive a
+// POST /api/sessions → GET /api/sessions/{id} round-trip.
+func TestCreateSession_MetadataRoundTrip(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	body := `{"shell":"pwsh","title":"meta","source":"zpit","project_id":"p","issue_id":"42","role":"coder","agent_state":"active"}`
+	resp, err := http.Post(ts.URL+"/api/sessions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/sessions failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	var created createSessionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("failed to decode create response: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("expected non-empty session ID")
+	}
+
+	getResp, err := http.Get(ts.URL + "/api/sessions/" + created.ID)
+	if err != nil {
+		t.Fatalf("GET /api/sessions/%s failed: %v", created.ID, err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", getResp.StatusCode)
+	}
+
+	var info session.SessionInfo
+	if err := json.NewDecoder(getResp.Body).Decode(&info); err != nil {
+		t.Fatalf("failed to decode session info: %v", err)
+	}
+
+	if info.Source != "zpit" {
+		t.Errorf("Source: expected %q, got %q", "zpit", info.Source)
+	}
+	if info.ProjectID != "p" {
+		t.Errorf("ProjectID: expected %q, got %q", "p", info.ProjectID)
+	}
+	if info.IssueID != "42" {
+		t.Errorf("IssueID: expected %q, got %q", "42", info.IssueID)
+	}
+	if info.Role != "coder" {
+		t.Errorf("Role: expected %q, got %q", "coder", info.Role)
+	}
+	if info.AgentState != "active" {
+		t.Errorf("AgentState: expected %q, got %q", "active", info.AgentState)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// agent_state validation on POST (AC-3)
+// ---------------------------------------------------------------------------
+
+// TestCreateSession_InvalidAgentState verifies that POST /api/sessions with an
+// invalid agent_state value returns HTTP 400 with the exact error message.
+func TestCreateSession_InvalidAgentState(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	body := `{"shell":"pwsh","title":"bad","agent_state":"bogus"}`
+	resp, err := http.Post(ts.URL+"/api/sessions", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /api/sessions failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", resp.StatusCode)
+	}
+
+	var errResp errorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if errResp.Error != "invalid agent_state" {
+		t.Errorf("expected error %q, got %q", "invalid agent_state", errResp.Error)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// agent_state on PATCH — valid path (AC-3)
+// ---------------------------------------------------------------------------
+
+// TestPatchSession_AgentState verifies that PATCH /api/sessions/{id} with a
+// valid agent_state value updates the field and returns 200 with the new info.
+func TestPatchSession_AgentState(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	id := createTestSession(t, ts, "patch-agent")
+
+	patchBody := `{"agent_state":"waiting"}`
+	req, err := http.NewRequest(http.MethodPatch, ts.URL+"/api/sessions/"+id, strings.NewReader(patchBody))
+	if err != nil {
+		t.Fatalf("failed to create PATCH request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH /api/sessions/%s failed: %v", id, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var info session.SessionInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		t.Fatalf("failed to decode session info: %v", err)
+	}
+	if info.AgentState != "waiting" {
+		t.Errorf("AgentState: expected %q, got %q", "waiting", info.AgentState)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// agent_state on PATCH — invalid path, session unchanged (AC-3)
+// ---------------------------------------------------------------------------
+
+// TestPatchSession_InvalidAgentState verifies that an invalid agent_state in
+// PATCH returns HTTP 400 and leaves the session's agent_state unchanged.
+func TestPatchSession_InvalidAgentState(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	id := createTestSession(t, ts, "patch-agent-invalid")
+
+	// First, set a known state via a valid PATCH.
+	validPatch := `{"agent_state":"active"}`
+	req1, err := http.NewRequest(http.MethodPatch, ts.URL+"/api/sessions/"+id, strings.NewReader(validPatch))
+	if err != nil {
+		t.Fatalf("failed to create PATCH request: %v", err)
+	}
+	req1.Header.Set("Content-Type", "application/json")
+	resp1, err := http.DefaultClient.Do(req1)
+	if err != nil {
+		t.Fatalf("PATCH (valid) failed: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 on valid PATCH, got %d", resp1.StatusCode)
+	}
+
+	// Now try an invalid agent_state.
+	invalidPatch := `{"agent_state":"explode"}`
+	req2, err := http.NewRequest(http.MethodPatch, ts.URL+"/api/sessions/"+id, strings.NewReader(invalidPatch))
+	if err != nil {
+		t.Fatalf("failed to create PATCH request: %v", err)
+	}
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatalf("PATCH (invalid) failed: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400 for invalid agent_state, got %d", resp2.StatusCode)
+	}
+
+	var errResp errorResponse
+	if err := json.NewDecoder(resp2.Body).Decode(&errResp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if errResp.Error != "invalid agent_state" {
+		t.Errorf("expected error %q, got %q", "invalid agent_state", errResp.Error)
+	}
+
+	// Verify the session state is still "active" (unchanged by the rejected patch).
+	getResp, err := http.Get(ts.URL + "/api/sessions/" + id)
+	if err != nil {
+		t.Fatalf("GET /api/sessions/%s failed: %v", id, err)
+	}
+	defer getResp.Body.Close()
+
+	var info session.SessionInfo
+	if err := json.NewDecoder(getResp.Body).Decode(&info); err != nil {
+		t.Fatalf("failed to decode session info: %v", err)
+	}
+	if info.AgentState != "active" {
+		t.Errorf("AgentState after invalid PATCH: expected %q, got %q", "active", info.AgentState)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SSE headers and event delivery (AC-4 + AC-13b)
+// ---------------------------------------------------------------------------
+
+// TestEvents_HeadersAndDelivery verifies that GET /api/events returns the
+// correct SSE headers and delivers a session.created event when a session is
+// created while the client is subscribed.
+func TestEvents_HeadersAndDelivery(t *testing.T) {
+	_, ts := newTestServer(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/events", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /api/events failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("expected Content-Type text/event-stream, got %q", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("expected Cache-Control no-cache, got %q", cc)
+	}
+	if conn := resp.Header.Get("Connection"); conn != "keep-alive" {
+		t.Errorf("expected Connection keep-alive, got %q", conn)
+	}
+
+	// Give the subscriber goroutine a moment to register, then create a session.
+	time.Sleep(200 * time.Millisecond)
+	go func() {
+		body := `{"shell":"pwsh","title":"sse-test"}`
+		http.Post(ts.URL+"/api/sessions", "application/json", strings.NewReader(body)) //nolint:errcheck
+	}()
+
+	// Read from the stream until we see a session.created event or time out.
+	resultCh := make(chan string, 1)
+	go func() {
+		reader := bufio.NewReader(resp.Body)
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				return
+			}
+			if strings.HasPrefix(line, "event: ") {
+				resultCh <- strings.TrimSpace(strings.TrimPrefix(line, "event: "))
+				return
+			}
+		}
+	}()
+
+	select {
+	case evType := <-resultCh:
+		if evType != "session.created" {
+			t.Errorf("expected first event type session.created, got %q", evType)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for session.created SSE event")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// responseWriter implements http.Flusher (AC-6)
+// ---------------------------------------------------------------------------
+
+// TestResponseWriterImplementsFlusher asserts that the responseWriter type
+// satisfies both http.Flusher and http.Hijacker at compile and runtime.
+func TestResponseWriterImplementsFlusher(t *testing.T) {
+	var rw interface{} = &responseWriter{}
+	if _, ok := rw.(http.Flusher); !ok {
+		t.Error("responseWriter does not implement http.Flusher")
+	}
+	if _, ok := rw.(http.Hijacker); !ok {
+		t.Error("responseWriter does not implement http.Hijacker")
 	}
 }

--- a/daemon/server/events.go
+++ b/daemon/server/events.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/zac15987/zplex/daemon/session"
+)
+
+// subscriberBufferSize is the capacity of each subscriber's event channel.
+// A channel that fills past this limit causes the event to be dropped for
+// that subscriber rather than blocking the broadcaster.
+const subscriberBufferSize = 16
+
+// HeartbeatInterval is how often the SSE handler writes a heartbeat comment.
+const HeartbeatInterval = 30 * time.Second
+
+// Event is a single SSE event broadcast to all subscribers.
+type Event struct {
+	Type    string // "session.created" | "session.closed" | "session.updated"
+	Session session.SessionInfo
+}
+
+// Hub manages a set of SSE subscriber channels and distributes events to them.
+// All exported methods are safe for concurrent use.
+type Hub struct {
+	mu          sync.Mutex
+	subscribers map[chan Event]struct{}
+}
+
+// NewHub creates a Hub with an empty subscriber set.
+func NewHub() *Hub {
+	return &Hub{
+		subscribers: make(map[chan Event]struct{}),
+	}
+}
+
+// Subscribe creates a buffered event channel, registers it with the Hub, and
+// returns it to the caller. The caller must call Unsubscribe when done to
+// release the channel and prevent goroutine leaks.
+func (h *Hub) Subscribe() chan Event {
+	ch := make(chan Event, subscriberBufferSize)
+
+	h.mu.Lock()
+	h.subscribers[ch] = struct{}{}
+	n := len(h.subscribers)
+	h.mu.Unlock()
+
+	slog.Info("server.handleEvents: subscriber connected",
+		slog.Int("subscribers", n),
+	)
+	return ch
+}
+
+// Unsubscribe removes the channel from the Hub and closes it exactly once.
+// Calling Unsubscribe with a channel that was never subscribed, or calling it
+// a second time for the same channel, is a safe no-op.
+func (h *Hub) Unsubscribe(ch chan Event) {
+	h.mu.Lock()
+	_, ok := h.subscribers[ch]
+	if ok {
+		delete(h.subscribers, ch)
+		close(ch)
+	}
+	n := len(h.subscribers)
+	h.mu.Unlock()
+
+	if ok {
+		slog.Info("server.events: subscriber removed",
+			slog.Int("subscribers", n),
+		)
+	}
+}
+
+// Broadcast sends ev to every registered subscriber using a non-blocking send.
+// If a subscriber's channel is full, the event is dropped for that subscriber
+// and a warning is logged. Broadcast never blocks on a slow consumer.
+func (h *Hub) Broadcast(ev Event) {
+	slog.Info("server.events: broadcasting",
+		slog.String("type", ev.Type),
+		slog.String("session_id", ev.Session.ID),
+	)
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for ch := range h.subscribers {
+		select {
+		case ch <- ev:
+		default:
+			slog.Warn("server.events: dropped event for slow subscriber",
+				slog.String("type", ev.Type),
+			)
+		}
+	}
+}

--- a/daemon/server/events_test.go
+++ b/daemon/server/events_test.go
@@ -1,0 +1,185 @@
+package server
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zac15987/zplex/daemon/session"
+)
+
+// testEvent builds a minimal Event for use in Hub tests.
+func testEvent(id string) Event {
+	return Event{Type: "session.created", Session: session.SessionInfo{ID: id}}
+}
+
+// ---------------------------------------------------------------------------
+// TestHub_SubscribeBroadcastReceive — single subscriber receives the event.
+// ---------------------------------------------------------------------------
+
+func TestHub_SubscribeBroadcastReceive(t *testing.T) {
+	h := NewHub()
+	ch := h.Subscribe()
+
+	ev := testEvent("sess-1")
+	h.Broadcast(ev)
+
+	select {
+	case got := <-ch:
+		if got.Type != ev.Type {
+			t.Errorf("expected Type %q, got %q", ev.Type, got.Type)
+		}
+		if got.Session.ID != ev.Session.ID {
+			t.Errorf("expected Session.ID %q, got %q", ev.Session.ID, got.Session.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event on subscriber channel")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestHub_BroadcastToMultipleSubscribers — all 3 subscribers receive the event.
+// ---------------------------------------------------------------------------
+
+func TestHub_BroadcastToMultipleSubscribers(t *testing.T) {
+	h := NewHub()
+
+	const numSubscribers = 3
+	channels := make([]chan Event, numSubscribers)
+	for i := range channels {
+		channels[i] = h.Subscribe()
+	}
+
+	ev := testEvent("sess-multi")
+	h.Broadcast(ev)
+
+	for i, ch := range channels {
+		select {
+		case got := <-ch:
+			if got.Session.ID != ev.Session.ID {
+				t.Errorf("subscriber %d: expected Session.ID %q, got %q", i, ev.Session.ID, got.Session.ID)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d: timed out waiting for event", i)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestHub_SlowSubscriberDropped — Broadcast never blocks when channel is full.
+// ---------------------------------------------------------------------------
+
+func TestHub_SlowSubscriberDropped(t *testing.T) {
+	h := NewHub()
+	ch := h.Subscribe() // buffer = subscriberBufferSize (16)
+
+	// Broadcast more events than the buffer can hold without draining.
+	// The key assertion is that Broadcast returns without blocking.
+	const broadcasts = 20
+	for i := 0; i < broadcasts; i++ {
+		h.Broadcast(testEvent("drop-test"))
+	}
+	// If we reach this line, Broadcast never blocked — assertion passes.
+
+	// Drain the channel and verify the count is within buffer capacity.
+	count := 0
+	for {
+		select {
+		case <-ch:
+			count++
+		default:
+			goto drained
+		}
+	}
+drained:
+	if count > subscriberBufferSize {
+		t.Errorf("drained %d events, expected at most %d (buffer capacity)", count, subscriberBufferSize)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestHub_DoubleUnsubscribeSafe — second Unsubscribe is a safe no-op.
+// ---------------------------------------------------------------------------
+
+func TestHub_DoubleUnsubscribeSafe(t *testing.T) {
+	h := NewHub()
+	ch := h.Subscribe()
+
+	// First Unsubscribe — should close the channel.
+	h.Unsubscribe(ch)
+
+	// Verify the channel is closed: a receive returns ok==false.
+	_, ok := <-ch
+	if ok {
+		t.Error("expected channel to be closed after Unsubscribe, but it was still open")
+	}
+
+	// Second Unsubscribe — must not panic.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("second Unsubscribe panicked: %v", r)
+		}
+	}()
+	h.Unsubscribe(ch)
+}
+
+// ---------------------------------------------------------------------------
+// TestHub_ConcurrentAccess — races detected by the Go race detector.
+// ---------------------------------------------------------------------------
+
+func TestHub_ConcurrentAccess(t *testing.T) {
+	h := NewHub()
+
+	const (
+		numSubscribers  = 10
+		broadcastsPerGo = 20
+	)
+
+	var wg sync.WaitGroup
+
+	// Goroutines that subscribe and then unsubscribe.
+	for i := 0; i < numSubscribers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ch := h.Subscribe()
+			// Drain the channel in a separate goroutine so we do not block
+			// the broadcaster (Broadcast is non-blocking, but cleanly emptying
+			// prevents the test goroutine from leaking a subscriber on return).
+			var drainWg sync.WaitGroup
+			drainWg.Add(1)
+			go func() {
+				defer drainWg.Done()
+				for range ch {
+					// discard
+				}
+			}()
+			h.Unsubscribe(ch)
+			drainWg.Wait()
+		}()
+	}
+
+	// Goroutines that broadcast concurrently.
+	for i := 0; i < numSubscribers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			for j := 0; j < broadcastsPerGo; j++ {
+				h.Broadcast(testEvent("concurrent"))
+			}
+		}(i)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All goroutines finished — no deadlock or panic.
+	case <-time.After(10 * time.Second):
+		t.Fatal("TestHub_ConcurrentAccess timed out — possible deadlock")
+	}
+}

--- a/daemon/server/router.go
+++ b/daemon/server/router.go
@@ -35,6 +35,7 @@ type Server struct {
 	layouts   map[string]layoutState // key = workspace ID
 	prefs     *prefs.Store
 	zpitCfg   config.ZpitConfig
+	hub       *Hub
 }
 
 // NewServer creates a Server wired to the given session manager, preferences
@@ -49,6 +50,7 @@ func NewServer(mgr *session.SessionManager, prefsStore *prefs.Store, zpitCfg con
 		layouts:   make(map[string]layoutState),
 		prefs:     prefsStore,
 		zpitCfg:   zpitCfg,
+		hub:       NewHub(),
 	}
 }
 
@@ -63,6 +65,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/sessions/{id}", s.handleGetSession)
 	mux.HandleFunc("DELETE /api/sessions/{id}", s.handleDeleteSession)
 	mux.HandleFunc("PATCH /api/sessions/{id}", s.handlePatchSession)
+
+	// SSE event stream
+	mux.HandleFunc("GET /api/events", s.handleEvents)
 
 	mux.HandleFunc("GET /api/layout", s.handleGetLayout)
 	mux.HandleFunc("PUT /api/layout", s.handlePutLayout)
@@ -118,6 +123,11 @@ type responseWriter struct {
 	statusCode int
 }
 
+// Compile-time checks that responseWriter implements the interfaces the
+// middleware relies on.
+var _ http.Flusher = (*responseWriter)(nil)
+var _ http.Hijacker = (*responseWriter)(nil)
+
 // WriteHeader captures the status code before delegating to the underlying
 // ResponseWriter.
 func (rw *responseWriter) WriteHeader(code int) {
@@ -133,6 +143,16 @@ func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 		return hj.Hijack()
 	}
 	return nil, nil, fmt.Errorf("underlying ResponseWriter does not implement http.Hijacker")
+}
+
+// Flush delegates to the underlying ResponseWriter's Flush method if it
+// implements http.Flusher. This is required for Server-Sent Events, which
+// must flush each event to the client immediately. It is a no-op when the
+// underlying writer is not a Flusher.
+func (rw *responseWriter) Flush() {
+	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 }
 
 // loggingMiddleware logs every HTTP request with method, path, status code,

--- a/daemon/session/manager.go
+++ b/daemon/session/manager.go
@@ -70,6 +70,14 @@ type CreateOptions struct {
 	Env   []string
 	Cwd   string
 	Kind  string
+	// Source, ProjectID, IssueID, Role are immutable agent-identity metadata
+	// set at creation time and not modified afterward.
+	Source    string
+	ProjectID string
+	IssueID   string
+	Role      string
+	// AgentState is the initial agent loop state: "" | "active" | "waiting" | "done".
+	AgentState string
 }
 
 // CreateSession spawns a new PTY-backed session with the given options.
@@ -82,6 +90,9 @@ func (m *SessionManager) CreateSession(opts CreateOptions) (*Session, error) {
 		slog.Int("cols", opts.Cols),
 		slog.Int("rows", opts.Rows),
 		slog.String("kind", opts.Kind),
+		slog.String("source", opts.Source),
+		slog.String("role", opts.Role),
+		slog.String("agent_state", opts.AgentState),
 	)
 
 	shell := opts.Shell
@@ -99,6 +110,14 @@ func (m *SessionManager) CreateSession(opts CreateOptions) (*Session, error) {
 		)
 		return nil, err
 	}
+
+	// Apply agent-identity metadata. The session is not yet shared (not in the
+	// manager map), so these assignments are safe without holding the lock.
+	sess.Source = opts.Source
+	sess.ProjectID = opts.ProjectID
+	sess.IssueID = opts.IssueID
+	sess.Role = opts.Role
+	sess.AgentState = opts.AgentState
 
 	// Resize if cols/rows specified.
 	if opts.Cols > 0 && opts.Rows > 0 {

--- a/daemon/session/manager_test.go
+++ b/daemon/session/manager_test.go
@@ -464,3 +464,68 @@ func TestFixedSession_Helper(t *testing.T) {
 		t.Errorf("expected FixedSession ID %q, got %q", fixedSess.ID, got.ID)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Metadata round-trip — AC-13(a) coverage.
+// ---------------------------------------------------------------------------
+
+func TestCreateSession_MetadataRoundTrip(t *testing.T) {
+	mgr := NewSessionManager("pwsh", 102400)
+	defer mgr.Shutdown()
+
+	sess, err := mgr.CreateSession(CreateOptions{
+		Shell:      "pwsh",
+		Title:      "meta-test",
+		Source:     "zpit",
+		ProjectID:  "p",
+		IssueID:    "42",
+		Role:       "coder",
+		AgentState: "active",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	info := sess.Info()
+	if info.Source != "zpit" {
+		t.Errorf("expected Source %q, got %q", "zpit", info.Source)
+	}
+	if info.ProjectID != "p" {
+		t.Errorf("expected ProjectID %q, got %q", "p", info.ProjectID)
+	}
+	if info.IssueID != "42" {
+		t.Errorf("expected IssueID %q, got %q", "42", info.IssueID)
+	}
+	if info.Role != "coder" {
+		t.Errorf("expected Role %q, got %q", "coder", info.Role)
+	}
+	if info.AgentState != "active" {
+		t.Errorf("expected AgentState %q, got %q", "active", info.AgentState)
+	}
+}
+
+func TestUpdateMeta_AgentState(t *testing.T) {
+	mgr := NewSessionManager("pwsh", 102400)
+	defer mgr.Shutdown()
+
+	sess, err := mgr.CreateSession(CreateOptions{
+		Shell:      "pwsh",
+		Title:      "t",
+		AgentState: "active",
+	})
+	if err != nil {
+		t.Fatalf("CreateSession failed: %v", err)
+	}
+
+	// Non-empty agentState should update the field.
+	sess.UpdateMeta("", "", "waiting")
+	if info := sess.Info(); info.AgentState != "waiting" {
+		t.Errorf("expected AgentState %q after UpdateMeta, got %q", "waiting", info.AgentState)
+	}
+
+	// Empty agentState should leave the field unchanged.
+	sess.UpdateMeta("", "", "")
+	if info := sess.Info(); info.AgentState != "waiting" {
+		t.Errorf("expected AgentState %q (unchanged) after UpdateMeta with empty string, got %q", "waiting", info.AgentState)
+	}
+}

--- a/daemon/session/session.go
+++ b/daemon/session/session.go
@@ -21,6 +21,13 @@ type SessionInfo struct {
 	PID       int       `json:"pid"`
 	ExitCode  int       `json:"exit_code"`
 	Kind      string    `json:"kind"`
+	// Identity fields — immutable, set at creation.
+	Source    string `json:"source"`
+	ProjectID string `json:"project_id"`
+	IssueID   string `json:"issue_id"`
+	Role      string `json:"role"`
+	// AgentState is the mutable agent loop state: "" | "active" | "waiting" | "done".
+	AgentState string `json:"agent_state"`
 }
 
 // Session represents a single PTY-backed terminal session.
@@ -34,6 +41,13 @@ type Session struct {
 	PID       int
 	ExitCode  int
 	Kind      string // "" = normal/agent session; "fixed" = zpit fixed panel
+	// Identity fields — immutable, set at creation.
+	Source    string
+	ProjectID string
+	IssueID   string
+	Role      string
+	// AgentState is the mutable agent loop state: "" | "active" | "waiting" | "done".
+	AgentState string
 
 	pty      pty.Pty     // PTY handle (ConPTY on Windows, /dev/ptmx on Unix)
 	cmd      *pty.Cmd    // the running subprocess
@@ -302,13 +316,18 @@ func (s *Session) Info() SessionInfo {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return SessionInfo{
-		ID:        s.ID,
-		Title:     s.Title,
-		Status:    s.Status,
-		CreatedAt: s.CreatedAt,
-		PID:       s.PID,
-		ExitCode:  s.ExitCode,
-		Kind:      s.Kind,
+		ID:         s.ID,
+		Title:      s.Title,
+		Status:     s.Status,
+		CreatedAt:  s.CreatedAt,
+		PID:        s.PID,
+		ExitCode:   s.ExitCode,
+		Kind:       s.Kind,
+		Source:     s.Source,
+		ProjectID:  s.ProjectID,
+		IssueID:    s.IssueID,
+		Role:       s.Role,
+		AgentState: s.AgentState,
 	}
 }
 
@@ -325,7 +344,9 @@ func (s *Session) Resize(cols, rows int) error {
 
 // UpdateMeta updates the session's mutable metadata fields.
 // Empty strings are ignored (only non-empty values are applied).
-func (s *Session) UpdateMeta(title, status string) {
+// agentState accepts "" | "active" | "waiting" | "done"; value validation
+// is performed at the API layer, not here.
+func (s *Session) UpdateMeta(title, status, agentState string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if title != "" {
@@ -334,10 +355,14 @@ func (s *Session) UpdateMeta(title, status string) {
 	if status != "" {
 		s.Status = status
 	}
+	if agentState != "" {
+		s.AgentState = agentState
+	}
 	slog.Info("session.UpdateMeta: metadata updated",
 		slog.String("session_id", s.ID),
 		slog.String("title", s.Title),
 		slog.String("status", s.Status),
+		slog.String("agent_state", s.AgentState),
 	)
 }
 

--- a/docs/zplex-project-plan.md
+++ b/docs/zplex-project-plan.md
@@ -206,7 +206,7 @@ zplex/
 
 ## 5. Milestones
 
-> **Progress (2026-06-09):** M1, M2, and M3 complete. M3 (issue #13) delivered the always-visible zpit cockpit: the daemon auto-launches a fixed `kind="fixed"` session on startup (configurable via `[zpit]`), protects it from deletion (DELETE → 403) with a `POST /api/zpit/restart` endpoint, and the frontend mounts it in a persistent `#main-split` fixed panel (draggable splitter, exited+Restart overlay, graceful fallback when zpit is absent). M4 (zpit launcher integration) is next.
+> **Progress (2026-06-09):** M1, M2, and M3 complete. M3 (issue #13) delivered the always-visible zpit cockpit: the daemon auto-launches a fixed `kind="fixed"` session on startup (configurable via `[zpit]`), protects it from deletion (DELETE → 403) with a `POST /api/zpit/restart` endpoint, and the frontend mounts it in a persistent `#main-split` fixed panel (draggable splitter, exited+Restart overlay, graceful fallback when zpit is absent). The three zplex-side M4 items are now complete — combined into issue #15 (the same way M3 combined its items into #13): the daemon session creation API with agent metadata (`source`, `project_id`, `issue_id`, `role`, `agent_state`), frontend panel status sync via SSE (`GET /api/events` → recolor panel header by `agent_state`: green=active, amber=waiting, grey=done), and frontend permission focus navigation (pulsing yellow border for `waiting` panels; `Ctrl+Shift+J` jumps to next waiting panel). The zpit-side launcher backend (`EnvZplex` detection + `launchZplex()`) remains tracked in the zpit repo as a separate work item.
 >
 > Note: The original plan's single "Go daemon" issue was split into #1 (session+PTY) and #2 (HTTP+WebSocket) during implementation. The original M2 "multi-panel layout" and "panel resize + keyboard navigation" items were combined into a single issue #7. M3's two planned items were combined into a single issue #13.
 
@@ -269,10 +269,10 @@ zplex/
 
 | Issue | Title | Description | Status | Depends |
 |---|---|---|---|---|
-| TBD | Daemon: session creation API with metadata | Extend POST /api/sessions to accept `source: "zpit"`, `project_id`, `issue_id`, `role` (coder/reviewer). Store metadata for UI display | Planned | M3 |
-| TBD | [zpit repo] New launcher backend: zplex | Add `platform.EnvZplex` detection (check if zplex daemon is running on port 17732). Add `launchZplex()` / `launchZplexInDir()` functions that POST to daemon API instead of exec wt.exe. Add `zplex_mode` to `TerminalConfig`. Fallback: if daemon unreachable, fall back to Windows Terminal | Planned | M3 |
-| TBD | Frontend: panel status sync with zpit loop | Daemon exposes SSE endpoint `/api/events` for panel status updates. When zpit loop transitions state (coding → reviewing → done), update panel header color/icon. Green = active, yellow = waiting permission, grey = done | Planned | zpit launcher |
-| TBD | Frontend: permission focus navigation | When zpit detects agent needs permission (existing signal file mechanism), zplex highlights that panel's border (pulsing yellow) and provides keyboard shortcut to jump to it | Planned | panel status sync |
+| #15 | Daemon: session creation API with metadata | Extend POST /api/sessions to accept `source: "zpit"`, `project_id`, `issue_id`, `role` (coder/reviewer), `agent_state`. Store metadata for UI display. PATCH /api/sessions/{id} updates `agent_state` | ✅ Done (#15) | M3 |
+| TBD | [zpit repo] New launcher backend: zplex | Add `platform.EnvZplex` detection (check if zplex daemon is running on port 17732). Add `launchZplex()` / `launchZplexInDir()` functions that POST to daemon API instead of exec wt.exe. Add `zplex_mode` to `TerminalConfig`. Fallback: if daemon unreachable, fall back to Windows Terminal (tracked in zpit repo, separate from #15) | Planned | M3 |
+| #15 | Frontend: panel status sync with zpit loop | Daemon exposes SSE endpoint `/api/events` for panel status updates. When zpit loop transitions state (coding → reviewing → done), update panel header color/icon. Green = active, amber = waiting permission, grey = done | ✅ Done (#15) | zpit launcher |
+| #15 | Frontend: permission focus navigation | When zpit detects agent needs permission (existing signal file mechanism), zplex highlights that panel's border (pulsing yellow) and provides keyboard shortcut (`Ctrl+Shift+J`) to jump to it | ✅ Done (#15) | panel status sync |
 
 **Integration architecture (M4 complete):**
 


### PR DESCRIPTION
## Summary

M4 "zpit deep integration" — the zplex-side feature that lets zpit-spawned Claude Code agents appear as panels automatically and reflect their loop state in the panel header. Combines the three planned M4 zplex-side items into one issue (#15), mirroring how M3 combined its items into #13.

Three layers, all in this repo:

1. **Daemon session metadata (identity + loop state).** `Session`/`SessionInfo` gain immutable identity fields `source`, `project_id`, `issue_id`, `role` and a mutable `agent_state` (`"" | "active" | "waiting" | "done"`), set at creation via `CreateOptions`/`createSessionRequest` and updatable via `PATCH /api/sessions/{id}`. `agent_state` is a generic 3-value enum deliberately decoupled from the PTY `status` field.
2. **SSE broadcaster + `GET /api/events`.** New `Hub` (events.go) with concurrency-safe subscribe/unsubscribe/broadcast (non-blocking send, drop+warn on slow subscribers) and a 30s heartbeat. Server emits `session.created` / `session.closed` / `session.updated` from the create/delete/patch handlers, plus `session.closed` on natural process exit via a per-session `Done()` watcher. Emission lives at the server-handler layer; the `session` package never imports the Hub. `responseWriter` now implements `http.Flusher` so SSE works behind `loggingMiddleware`.
3. **Frontend real-time sync + permission navigation.** On init the frontend opens an `EventSource` to `/api/events`. `session.created` auto-mounts a non-fixed, not-already-mounted session into the active workspace (8-panel cap respected; registry-presence dedup guard prevents double-mount). `session.updated` recolors the panel header status indicator by `agent_state`. `session.closed` removes the panel without issuing another DELETE. `waiting` adds a pulsing amber border; `Ctrl+Shift+J` cycles focus through waiting panels in grid order (wrap-around).

## Decisions recorded

- Combined single issue (user confirmed).
- Generic `agent_state` enum decoupled from PTY `status` and from zpit's internal loop names (user confirmed); maps cleanly to green/amber/grey.
- Auto-mount to the active workspace because sessions carry no workspace affinity (user confirmed).
- `Ctrl+Shift+J` for the waiting-panel jump (user confirmed; the slot was free).
- `session.closed` is emitted by both the DELETE handler and the `Done()` watcher per AC-5; the frontend ignores a closed event for an already-removed panel, so the duplicate is harmless — no dedup logic added.
- The zpit-side launcher backend (`EnvZplex` / `launchZplex()`) is out of scope here and remains tracked in the zpit repo.

## Testing

- `go test ./...` (from `daemon/`) — all packages pass, including new tests:
  - `session/manager_test.go`: metadata round-trip through `CreateSession`→`Info()`; `UpdateMeta` agent_state semantics.
  - `server/api_test.go`: POST+GET metadata round-trip; PATCH valid/invalid `agent_state` (400 + unchanged); SSE headers + live `session.created` delivery; `responseWriter` implements `http.Flusher`.
  - `server/events_test.go`: Hub concurrency, slow-subscriber drop, double-Unsubscribe safety (under `-race`).
- `npm run typecheck` (from `app/`) — zero errors under strict mode, no `any`.
- `go build ./...` and `go vet ./...` clean.

## Acceptance criteria

All AC-1 … AC-17 verified against concrete artifacts (fields/JSON tags, exact `invalid agent_state` 400, SSE frame `event: <type>\ndata: <json>\n\n` + `: heartbeat\n\n`, exact agent-state hex colors, Ctrl+Shift+J cycle, CLAUDE.md + project-plan docs).

Closes #15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
